### PR TITLE
the rough backend implementation for the purpose session

### DIFF
--- a/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/constants/constants.dart
+++ b/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/constants/constants.dart
@@ -1,0 +1,5 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
+mixin NokhteSessionsAudioConstants {
+  String BUCKET = "nokhte-sessions-audio";
+}

--- a/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/nokhte_sessions_audio_storage_queries.dart
+++ b/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/nokhte_sessions_audio_storage_queries.dart
@@ -1,0 +1,54 @@
+// ignore_for_file: constant_identifier_names
+import 'package:nokhte_backend/storage/buckets/shared/path_and_bytes.dart';
+import 'package:nokhte_backend/tables//active_nokhte_sessions.dart';
+import 'package:nokhte_backend/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'types/types.dart';
+import 'constants/constants.dart';
+import "../shared/shared.dart";
+export "../shared/shared.dart";
+
+class NokhteSessionsAudioStorageQueries with NokhteSessionsAudioConstants {
+  final ActiveNokhteSessionQueries activeQueries;
+  final FinishedNokhteSessionQueries finishedQueries;
+  final SupabaseClient supabase;
+  NokhteSessionsAudioStorageQueries({
+    required this.supabase,
+  })  : activeQueries = ActiveNokhteSessionQueries(supabase: supabase),
+        finishedQueries = FinishedNokhteSessionQueries(supabase: supabase) {
+    supabase.storage.setAuth(supabase.auth.currentSession?.accessToken ?? '');
+  }
+
+  upload(UploadNokhteSessionAudioParams params) async {
+    await activeQueries.addNewAudioClipToSessionMetadata(params.audioID);
+    final path = await activeQueries.composePath(params.audioID);
+    await supabase.storage.from(BUCKET).upload(path, params.file);
+  }
+
+  Future<List<PathAndBytes>> download({
+    required String collaboratorUID,
+    required int sessionIndex,
+  }) async {
+    final List<PathAndBytes> returnList = [];
+    final audioPaths = await finishedQueries.getAudioPathsFromSession(
+      collaboratorUID,
+      sessionIndex,
+    );
+    for (final path in audioPaths) {
+      final rawBytes = await supabase.storage.from(BUCKET).download(path);
+      final pathAndFile = PathAndBytes(path: path, rawBytes: rawBytes);
+      returnList.add(pathAndFile);
+    }
+    return returnList;
+  }
+
+  nuke({required String collaboratorUID}) async {
+    final audioPaths = await finishedQueries.getAudioPathsFromSession(
+      collaboratorUID,
+      0,
+    );
+    for (final path in audioPaths) {
+      await supabase.storage.from(BUCKET).remove([path]);
+    }
+  }
+}

--- a/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/types/types.dart
+++ b/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/types/types.dart
@@ -1,0 +1,1 @@
+export "upload_nokhte_session_audio_params.dart";

--- a/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/types/upload_nokhte_session_audio_params.dart
+++ b/packages/backend/dart/lib/storage/buckets/nokhte_sessions_audio/types/upload_nokhte_session_audio_params.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:equatable/equatable.dart';
+
+class UploadNokhteSessionAudioParams extends Equatable {
+  final String audioID;
+  final File file;
+
+  UploadNokhteSessionAudioParams({
+    required this.audioID,
+    required this.file,
+  });
+
+  @override
+  List<Object> get props => [audioID, file];
+}

--- a/packages/backend/dart/lib/storage/buckets/perspectives_audio/perspectives_audio_storage_queries.dart
+++ b/packages/backend/dart/lib/storage/buckets/perspectives_audio/perspectives_audio_storage_queries.dart
@@ -2,6 +2,8 @@ import 'package:nokhte_backend/storage/buckets/utilities/storage_utilities.dart'
 import 'package:nokhte_backend/tables/_real_time_enabled/shared/shared.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'types/types.dart';
+import "../shared/shared.dart";
+export "../shared/shared.dart";
 
 class PerspectivesAudioStorageQueries extends CollaborativeQueries {
   static get bucketName => "perspectives_audio";

--- a/packages/backend/dart/lib/storage/buckets/perspectives_audio/types/types.dart
+++ b/packages/backend/dart/lib/storage/buckets/perspectives_audio/types/types.dart
@@ -1,7 +1,6 @@
 export 'collective_session_audio_extrapolation_info.dart';
 export 'individual_session_audio_clip.dart';
 export 'individual_session_metadata.dart';
-export 'path_and_bytes.dart';
 export 'perspective_metadata.dart';
 export 'start_and_end_paths.dart';
 export 'perspectives_audio_path_components.dart';

--- a/packages/backend/dart/lib/storage/buckets/shared/path_and_bytes.dart
+++ b/packages/backend/dart/lib/storage/buckets/shared/path_and_bytes.dart
@@ -1,5 +1,4 @@
 import 'dart:typed_data';
-
 import 'package:equatable/equatable.dart';
 
 class PathAndBytes extends Equatable {

--- a/packages/backend/dart/lib/storage/buckets/shared/shared.dart
+++ b/packages/backend/dart/lib/storage/buckets/shared/shared.dart
@@ -1,0 +1,1 @@
+export "path_and_bytes.dart";

--- a/packages/backend/dart/lib/storage/nokhte_sessions_audio.dart
+++ b/packages/backend/dart/lib/storage/nokhte_sessions_audio.dart
@@ -1,0 +1,2 @@
+export "./buckets/nokhte_sessions_audio/nokhte_sessions_audio_storage_queries.dart";
+export "./buckets/nokhte_sessions_audio/constants/constants.dart";

--- a/packages/backend/dart/lib/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart
@@ -15,27 +15,43 @@ class FinishedNokhteSessionQueries {
       : userUID = supabase.auth.currentUser?.id ?? '';
 
   Future<List> insert({
-    required String collaboratorOneUID,
-    required String collaboratorTwoUID,
+    required List<String> collaboratorUIDs,
+    required List<Map> sessionMetadata,
+    required String sessionTimestamp,
   }) async =>
-      await supabase.from(TABLE_NAME).insert({
-        COLLABORATOR_ONE_UID: collaboratorOneUID,
-        COLLABORATOR_TWO_UID: collaboratorTwoUID,
+      await supabase.from(TABLE).insert({
+        COLLABORATOR_UIDS: collaboratorUIDs,
+        SESSION_METADATA: sessionMetadata,
+        SESSION_TIMESTAMP: sessionTimestamp,
       }).select();
 
-  Future<List> select({
-    required String collaboratorOneUID,
-    required String collaboratorTwoUID,
-  }) async =>
-      await supabase
-          .from(TABLE_NAME)
-          .select()
-          .eq(
-            COLLABORATOR_ONE_UID,
-            collaboratorOneUID,
-          )
-          .eq(
-            COLLABORATOR_TWO_UID,
-            collaboratorTwoUID,
-          );
+  Future<List> select() async => await supabase.from(TABLE).select();
+
+  Future<List> selectByCollaborationId(String collaboratorUID) async {
+    final sortedCollaboratorUIDs = [userUID, collaboratorUID]..sort();
+    return await supabase
+        .from(TABLE)
+        .select()
+        .eq(COLLABORATOR_UIDS, sortedCollaboratorUIDs);
+  }
+
+  Future<List<String>> getAudioPathsFromSession(
+      String collaboratorUID, int sessionIndex) async {
+    final sessions = await selectByCollaborationId(collaboratorUID);
+    if (sessions.isEmpty) {
+      return [];
+    } else {
+      final List<String> paths = [];
+      final session = sessions[sessionIndex];
+      final collaboratorIDs = session[COLLABORATOR_UIDS].join('_');
+      final sessionTimestamp = session[SESSION_TIMESTAMP];
+      final sessionMetadata = session[SESSION_METADATA];
+      for (int i = 0; i < sessionMetadata.length; i++) {
+        paths.add(
+          '$collaboratorIDs/$sessionTimestamp/${sessionMetadata[i]["audioID"]}.wav',
+        );
+      }
+      return paths;
+    }
+  }
 }

--- a/packages/backend/dart/lib/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart
@@ -3,9 +3,10 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class FinishedNokhteSessionQueries {
-  static const TABLE_NAME = 'finished_nokhte_sessions';
-  static const COLLABORATOR_ONE_UID = 'collaborator_one_uid';
-  static const COLLABORATOR_TWO_UID = 'collaborator_two_uid';
+  static const TABLE = 'finished_nokhte_sessions';
+  static const COLLABORATOR_UIDS = 'collaborator_uids';
+  static const SESSION_TIMESTAMP = 'session_timestamp';
+  static const SESSION_METADATA = 'session_metadata';
 
   final SupabaseClient supabase;
   final String userUID;

--- a/packages/backend/dart/lib/tables/_real_time_disabled/user_names/constants.dart
+++ b/packages/backend/dart/lib/tables/_real_time_disabled/user_names/constants.dart
@@ -1,0 +1,14 @@
+// ignore_for_file: non_constant_identifier_names
+
+mixin UserNamesConstants {
+  String get TABLE => 'user_names';
+  String get FIRST_NAME => 'first_name';
+  String get AUTHORIZED_VIEWERS => 'authorized_viewers';
+  String get LAST_NAME => 'last_name';
+  String get UID => 'uid';
+  String get HAS_SENT_AN_INVITATION => 'has_sent_an_invitation';
+  String get HAS_GONE_THROUGH_INVITATION_FLOW =>
+      'has_gone_through_invitation_flow';
+  String get WANTS_TO_REPEAT_INVITATION_FLOW =>
+      'wants_to_repeat_invitation_flow';
+}

--- a/packages/backend/dart/lib/tables/_real_time_disabled/user_names/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_disabled/user_names/queries.dart
@@ -1,15 +1,7 @@
+import 'constants.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-class UserNamesQueries {
-  static String get tableName => 'user_names';
-  static String get firstName => 'first_name';
-  static String get lastName => 'last_name';
-  static String get uid => 'uid';
-  static String get hasSentAnInvitation => 'has_sent_an_invitation';
-  static String get hasGoneThroughInvitationFlow =>
-      'has_gone_through_invitation_flow';
-  static String get wantsToRepeatInvitationFlow =>
-      'wants_to_repeat_invitation_flow';
+class UserNamesQueries with UserNamesConstants {
   final SupabaseClient supabase;
   String userUID;
 
@@ -18,69 +10,71 @@ class UserNamesQueries {
   }) : userUID = supabase.auth.currentUser?.id ?? '';
 
   Future<List> insertUserInfo({
-    required String firstNameParam,
-    required String lastNameParam,
+    required String firstName,
+    required String lastName,
   }) async =>
-      await supabase.from(tableName).insert({
-        uid: userUID,
-        firstName: firstNameParam,
-        lastName: lastNameParam,
+      await supabase.from(TABLE).insert({
+        UID: userUID,
+        FIRST_NAME: firstName,
+        LAST_NAME: lastName,
       }).select();
 
   Future<List> getUserInfo() async =>
-      await supabase.from(tableName).select().eq(uid, userUID);
+      await supabase.from(TABLE).select().eq(UID, userUID);
 
   Future<List> deleteUserInfo() async =>
-      await supabase.from(tableName).delete().eq(uid, userUID).select();
+      await supabase.from(TABLE).delete().eq(UID, userUID).select();
 
-  Future<List> updateHasSentAnInvitation(bool hasSentAnInvitationParam) async {
+  Future<List> updateHasSentAnInvitation(bool hasSentAnInvitation) async {
     final getRes = await getUserInfo();
-    if (getRes.first[hasSentAnInvitation] == hasSentAnInvitationParam) {
+    if (getRes.first[HAS_SENT_AN_INVITATION] == hasSentAnInvitation) {
       return getRes;
     } else {
       return await supabase
-          .from(tableName)
+          .from(TABLE)
           .update({
-            hasSentAnInvitation: hasSentAnInvitationParam,
+            HAS_SENT_AN_INVITATION: hasSentAnInvitation,
           })
-          .eq(uid, userUID)
+          .eq(UID, userUID)
           .select();
     }
   }
 
   Future<List> updateHasGoneThroughInvitationFlow(
-    bool hasGoneThroughInvitationFlowParam,
+    bool hasGoneThroughInvitationFlow,
   ) async {
     final getRes = await getUserInfo();
-    if (getRes.first[hasGoneThroughInvitationFlow] ==
-        hasGoneThroughInvitationFlowParam) {
+    if (getRes.first[HAS_GONE_THROUGH_INVITATION_FLOW] ==
+        hasGoneThroughInvitationFlow) {
       return getRes;
     } else {
       return await supabase
-          .from(tableName)
+          .from(TABLE)
           .update({
-            hasGoneThroughInvitationFlow: hasGoneThroughInvitationFlowParam,
+            HAS_GONE_THROUGH_INVITATION_FLOW: hasGoneThroughInvitationFlow,
           })
-          .eq(uid, userUID)
+          .eq(UID, userUID)
           .select();
     }
   }
 
   Future<List> updateWantsToRepeatInvitationFlow(
-    bool wantsToRepeatInvitationFlowParam,
-  ) async {
+      bool wantsToRepeatInvitationFlow) async {
     final getRes = await getUserInfo();
-    if (getRes.first[wantsToRepeatInvitationFlow] ==
-        wantsToRepeatInvitationFlowParam) {
+    if (getRes.first[WANTS_TO_REPEAT_INVITATION_FLOW] ==
+        wantsToRepeatInvitationFlow) {
       return getRes;
     } else {
       return await supabase
-          .from(tableName)
+          .from(TABLE)
           .update({
-            wantsToRepeatInvitationFlow: wantsToRepeatInvitationFlowParam,
+            WANTS_TO_REPEAT_INVITATION_FLOW: wantsToRepeatInvitationFlow,
           })
-          .eq(uid, userUID)
+          .eq(UID, userUID)
           .select();
     }
   }
+
+  Future<List> getCollaboratorRows() async =>
+      await supabase.from(TABLE).select().neq('uid', userUID);
 }

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/constants/constants.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/constants/constants.dart
@@ -1,12 +1,13 @@
 // ignore_for_file: constant_identifier_names, non_constant_identifier_names
 
 mixin ActiveNokhteSessionsConstants {
-  String TABLE_NAME = "active_nokhte_sessions";
+  String TABLE = "active_nokhte_sessions";
   String MEETING_UID = 'meeting_uid';
-  String COLLABORATOR_ONE_UID = 'collaborator_one_uid';
-  String COLLABORATOR_TWO_UID = 'collaborator_two_uid';
+  String COLLABORATOR_UIDS = 'collaborator_uids';
   String SPEAKER_SPOTLIGHT = 'speaker_spotlight';
   String CURRENT_PHASES = 'current_phases';
   String IS_ONLINE = 'is_online';
   String CREATED_AT = 'created_at';
+  String SESSION_METADATA = 'session_metadata';
+  String METADATA_INDEX = 'metadata_index';
 }

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -156,6 +156,20 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     );
   }
 
+  updateCurrentMetadataIndexContent(String newContent) async {
+    await computeCollaboratorInformation();
+    final currentMetadataIndex = await getMetadataIndex();
+    final currentSessionMetadata = await getSessionMetadata();
+    currentSessionMetadata[currentMetadataIndex]['content'] = newContent;
+    return await _onCurrentActiveNokhteSession(
+      supabase.from(TABLE).update(
+        {
+          SESSION_METADATA: currentSessionMetadata,
+        },
+      ),
+    );
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
     return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -127,6 +127,16 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     return '${collaboratorOneUID}_$collaboratorTwoUID/$timestamp/$audioID.wav';
   }
 
+  Future<List> incrementMetadataIndex() async {
+    await computeCollaboratorInformation();
+    final currentMetadataIndex = await getMetadataIndex();
+    return await _onCurrentActiveNokhteSession(
+      supabase.from(TABLE).update({
+        METADATA_INDEX: currentMetadataIndex + 1,
+      }),
+    );
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
     return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -189,6 +189,17 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     return audioPathsList;
   }
 
+  completeSession() async {
+    final sessionMetadata = await getSessionMetadata();
+    final sessionTimestamp = await getCreatedAt();
+    await supabase.from(FinishedNokhteSessionQueries.TABLE).insert({
+      FinishedNokhteSessionQueries.COLLABORATOR_UIDS: collaboratorUIDs,
+      FinishedNokhteSessionQueries.SESSION_METADATA: sessionMetadata,
+      FinishedNokhteSessionQueries.SESSION_TIMESTAMP: sessionTimestamp,
+    });
+    await delete();
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
     return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -68,8 +68,7 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     final indexToEdit =
         shouldEditCollaboratorsInfo ? collaboratorIndex : userIndex;
     currentOnlineStatus[indexToEdit] = isOnlineParam;
-    return await _onCurrentActiveNokhteSession(
-        supabase.from(TABLE_NAME).update({
+    return await _onCurrentActiveNokhteSession(supabase.from(TABLE).update({
       IS_ONLINE: currentOnlineStatus,
     }));
   }
@@ -83,8 +82,7 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     final indexToEdit =
         shouldEditCollaboratorsInfo ? collaboratorIndex : userIndex;
     currentPhases[indexToEdit] = newPhase;
-    return await _onCurrentActiveNokhteSession(
-        supabase.from(TABLE_NAME).update({
+    return await _onCurrentActiveNokhteSession(supabase.from(TABLE).update({
       CURRENT_PHASES: currentPhases,
     }));
   }
@@ -94,7 +92,7 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     final currentSpeaker = await getSpeakerSpotlight();
     if (currentSpeaker == null) {
       return await _onCurrentActiveNokhteSession(
-        supabase.from(TABLE_NAME).update({
+        supabase.from(TABLE).update({
           SPEAKER_SPOTLIGHT: userUID,
         }),
       );
@@ -108,7 +106,7 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     final currentSpeaker = await getSpeakerSpotlight();
     if (currentSpeaker == userUID) {
       return await _onCurrentActiveNokhteSession(
-          supabase.from(TABLE_NAME).update({SPEAKER_SPOTLIGHT: null}));
+          supabase.from(TABLE).update({SPEAKER_SPOTLIGHT: null}));
     } else {
       return [];
     }

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -170,6 +170,25 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     );
   }
 
+  getAudioIds() async {
+    final sessionMetadata = await getSessionMetadata();
+    final List<String> audioIDs = [];
+    for (int i = 0; i < sessionMetadata.length; i++) {
+      audioIDs.add(sessionMetadata[i]['audioID']);
+    }
+    return audioIDs;
+  }
+
+  getAudioIdPaths() async {
+    final List<String> audioPathsList = [];
+    final audioIds = await getAudioIds();
+    for (int i = 0; i < audioIds.length; i++) {
+      final fullPath = await composePath(audioIds[i]);
+      audioPathsList.add(fullPath);
+    }
+    return audioPathsList;
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
     return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -119,11 +119,16 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     return meetingUID == userUID;
   }
 
+  Future<String> composePath(String audioID) async {
+    await computeCollaboratorInformation();
+    if (timestamp.isEmpty) {
+      timestamp = await getCreatedAt();
+    }
+    return '${collaboratorOneUID}_$collaboratorTwoUID/$timestamp/$audioID.wav';
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
-    return await query
-        .eq(userColumn, userUID)
-        .eq(collaboratorColumn, collaboratorUID)
-        .select();
+    return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();
   }
 }

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -137,6 +137,25 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     );
   }
 
+  addNewAudioClipToSessionMetadata(String newAudioID) async {
+    await computeCollaboratorInformation();
+    final currentSessionMetadata = await getSessionMetadata();
+    currentSessionMetadata.add({
+      'audioID': newAudioID,
+      'content': '',
+    });
+    if (currentSessionMetadata.length > 1) {
+      await incrementMetadataIndex();
+    }
+    return await _onCurrentActiveNokhteSession(
+      supabase.from(TABLE).update(
+        {
+          SESSION_METADATA: currentSessionMetadata,
+        },
+      ),
+    );
+  }
+
   _onCurrentActiveNokhteSession(PostgrestFilterBuilder query) async {
     await computeCollaboratorInformation();
     return await query.eq(COLLABORATOR_UIDS, collaboratorUIDs).select();

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -1,5 +1,5 @@
 // ignore_for_file: constant_identifier_names
-
+import 'package:nokhte_backend/tables/finished_nokhte_sessions.dart';
 import 'constants/constants.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -38,26 +38,27 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
     required this.supabase,
   }) : userUID = supabase.auth.currentUser?.id ?? '';
 
-  select() async => await supabase.from(TABLE_NAME).select();
+  select() async => await supabase.from(TABLE).select();
 
-  delete() async => await supabase
-      .from(TABLE_NAME)
-      .delete()
-      .or('collaborator_one_uid.eq.$userUID, collaborator_two_uid.eq.$userUID')
-      .select();
+  delete() async =>
+      await _onCurrentActiveNokhteSession(supabase.from(TABLE).delete());
 
   Future _getProperty(String property) async =>
       (await select()).first[property];
 
   Future<String> getMeetingUID() async => await _getProperty(MEETING_UID);
   Future<String> getCollaboratorOne() async =>
-      await _getProperty(COLLABORATOR_ONE_UID);
+      (await _getProperty(COLLABORATOR_UIDS))[0];
   Future<String> getCollaboratorTwo() async =>
-      await _getProperty(COLLABORATOR_TWO_UID);
+      (await _getProperty(COLLABORATOR_UIDS))[1];
   Future<List> getWhoIsOnline() async => await _getProperty(IS_ONLINE);
   Future<String?> getSpeakerSpotlight() async =>
       await _getProperty(SPEAKER_SPOTLIGHT);
   Future<List> getCurrentPhases() async => await _getProperty(CURRENT_PHASES);
+  Future<String> getCreatedAt() async => await _getProperty(CREATED_AT);
+  Future<int> getMetadataIndex() async => await _getProperty(METADATA_INDEX);
+  Future<List> getSessionMetadata() async =>
+      await _getProperty(SESSION_METADATA);
 
   Future<List> updateOnlineStatus(
     bool isOnlineParam, {

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/queries.dart
@@ -9,24 +9,27 @@ class ActiveNokhteSessionQueries with ActiveNokhteSessionsConstants {
   int userIndex = -1;
   int collaboratorIndex = -1;
   String collaboratorUID = '';
-  String userColumn = '';
-  String collaboratorColumn = '';
+  String timestamp = '';
+  String collaboratorOneUID = '';
+  String collaboratorTwoUID = '';
+  List collaboratorUIDs = [];
 
   computeCollaboratorInformation() async {
     if (userIndex == -1) {
       final row = (await select()).first;
-      if (row[COLLABORATOR_ONE_UID] == userUID) {
+      if (row[COLLABORATOR_UIDS][0] == userUID) {
+        collaboratorUIDs = row[COLLABORATOR_UIDS];
         userIndex = 0;
+        collaboratorOneUID = userUID;
+        collaboratorTwoUID = row[COLLABORATOR_UIDS][1];
         collaboratorIndex = 1;
-        collaboratorUID = row[COLLABORATOR_TWO_UID];
-        userColumn = COLLABORATOR_ONE_UID;
-        collaboratorColumn = COLLABORATOR_TWO_UID;
+        collaboratorUID = row[COLLABORATOR_UIDS][1];
       } else {
+        collaboratorTwoUID = userUID;
+        collaboratorOneUID = row[COLLABORATOR_UIDS][0];
         userIndex = 1;
         collaboratorIndex = 0;
-        collaboratorUID = row[COLLABORATOR_ONE_UID];
-        userColumn = COLLABORATOR_TWO_UID;
-        collaboratorColumn = COLLABORATOR_ONE_UID;
+        collaboratorUID = row[COLLABORATOR_UIDS][0];
       }
     }
   }

--- a/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/streams.dart
+++ b/packages/backend/dart/lib/tables/_real_time_enabled/active_nokhte_sessions/streams.dart
@@ -10,7 +10,6 @@ class ActiveNokhteSessionsStream extends ActiveNokhteSessionQueries
   bool sessionMetadataListeningStatus = false;
 
   ActiveNokhteSessionsStream({required super.supabase});
-  // : userUID = supabase.auth.currentUser?.id ?? '';
 
   cancelGetActiveNokhteSessionCreationStatus() {
     getActiveNokhteSessionCreationListingingStatus = false;
@@ -19,8 +18,7 @@ class ActiveNokhteSessionsStream extends ActiveNokhteSessionQueries
 
   Stream<bool> getActiveNokhteSessionCreationStatus() async* {
     getActiveNokhteSessionCreationListingingStatus = true;
-    await for (var event
-        in supabase.from(TABLE_NAME).stream(primaryKey: ['id'])) {
+    await for (var event in supabase.from(TABLE).stream(primaryKey: ['id'])) {
       if (!getActiveNokhteSessionCreationListingingStatus) {
         break;
       }
@@ -37,10 +35,9 @@ class ActiveNokhteSessionsStream extends ActiveNokhteSessionQueries
     return sessionMetadataListeningStatus;
   }
 
-  Stream<NokhteSessionMetadata> getSessionMetadata() async* {
+  Stream<NokhteSessionMetadata> getPresenceMetadata() async* {
     sessionMetadataListeningStatus = true;
-    await for (var event
-        in supabase.from(TABLE_NAME).stream(primaryKey: ['id'])) {
+    await for (var event in supabase.from(TABLE).stream(primaryKey: ['id'])) {
       if (event.isEmpty) {
         yield NokhteSessionMetadata.initial();
       } else {

--- a/packages/backend/dart/lib/tables/user_names.dart
+++ b/packages/backend/dart/lib/tables/user_names.dart
@@ -1,1 +1,2 @@
 export '_real_time_disabled/user_names/queries.dart';
+export "./_real_time_disabled/user_names/constants.dart";

--- a/packages/backend/dart/scripts/test.sh
+++ b/packages/backend/dart/scripts/test.sh
@@ -11,3 +11,4 @@ flutter test test/09_p2p_perspectives_tracking_table_test.dart
 flutter test test/10_active_nokhte_sessions_table_test.dart
 flutter test test/11_individual_sessions_and_perspectives_audio_storage_test.dart
 flutter test test/12_finished_nokhte_sessions_table_test.dart
+flutter test test/13_nokhte_sessions_audio_bucket_test.dart

--- a/packages/backend/dart/scripts/test.sh
+++ b/packages/backend/dart/scripts/test.sh
@@ -1,4 +1,5 @@
 flutter test test/01_user_names_table_test.dart
+flutter test test/01.5_user_names_table_test.dart
 flutter test test/02_get_agora_token_test.dart
 flutter test test/03_synchronous_search_test.dart
 flutter test test/04_existing_collaborations_table_test.dart

--- a/packages/backend/dart/test/01.5_user_names_table_test.dart
+++ b/packages/backend/dart/test/01.5_user_names_table_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nokhte_backend/tables/_real_time_disabled/user_names/queries.dart';
+
+import 'shared/shared.dart';
+
+void main() {
+  late UserNamesQueries user1Queries;
+  final tSetup = CommonCollaborativeTestFunctions();
+
+  setUp(() async {
+    await tSetup.setUp(shouldMakeCollaboration: false);
+    user1Queries = UserNamesQueries(supabase: tSetup.user1Supabase);
+  });
+
+  group("getCollaboratorRows", () {
+    tearDownAll(
+        () async => await tSetup.supabaseAdmin.from('user_names').update({
+              "authorized_viewers": [],
+            }).eq('uid', tSetup.secondUserUID));
+    test("shoulnd't be able to read anything if nothing is shared", () async {
+      final initialRes = await user1Queries.getCollaboratorRows();
+      expect(initialRes, isEmpty);
+    });
+    test("should be able to read collaborators row (if shared)", () async {
+      await tSetup.supabaseAdmin.from('user_names').update({
+        "authorized_viewers": [tSetup.firstUserUID],
+      }).eq('uid', tSetup.secondUserUID);
+      final postRes = await user1Queries.getCollaboratorRows();
+      expect(postRes, isNotEmpty);
+      await tSetup.supabaseAdmin.from('user_names').update({
+        "authorized_viewers": [tSetup.firstUserUID],
+      }).eq('uid', tSetup.secondUserUID);
+    });
+  });
+}

--- a/packages/backend/dart/test/01_user_names_table_test.dart
+++ b/packages/backend/dart/test/01_user_names_table_test.dart
@@ -11,7 +11,7 @@ import 'package:nokhte_backend/constants/constants.dart';
 void main() {
   late SupabaseClient supabaseAdmin;
   late SupabaseClient supabase;
-  late String? currentUserUID;
+  late String? firstUserUID;
   late UserNamesQueries user1UserNameQueries;
   late UserNamesQueries adminUserNameQueries;
 
@@ -20,11 +20,11 @@ void main() {
     supabaseAdmin = SupabaseClientConfigConstants.supabaseAdmin;
     await UserSetupConstants.wipeUsernamesTable(supabaseAdmin: supabaseAdmin);
     final userIdResults = await UserSetupConstants.getUIDs();
-    currentUserUID = userIdResults.first;
+    firstUserUID = userIdResults.first;
     await SignIn.user1(supabase: supabase);
     user1UserNameQueries = UserNamesQueries(supabase: supabase);
     adminUserNameQueries = UserNamesQueries(supabase: supabaseAdmin);
-    adminUserNameQueries.userUID = currentUserUID ?? '';
+    adminUserNameQueries.userUID = firstUserUID ?? '';
   });
 
   tearDown(() async {
@@ -41,65 +41,69 @@ void main() {
       "✅ should be able to CREATE & READ a row in the table if their uid isn't present already",
       () async {
     final userNamesRes = await user1UserNameQueries.insertUserInfo(
-      firstNameParam: UserDataConstants.user1FirstName,
-      lastNameParam: UserDataConstants.user1LastName,
+      firstName: UserDataConstants.user1FirstName,
+      lastName: UserDataConstants.user1LastName,
     );
     expect(userNamesRes.first['first_name'], UserDataConstants.user1FirstName);
     expect(userNamesRes.first["last_name"], UserDataConstants.user1LastName);
-    expect(userNamesRes.first["uid"], currentUserUID);
+    expect(userNamesRes.first["uid"], firstUserUID);
   });
 
   test("should be able to update their `has_sent_invitation` field", () async {
     await user1UserNameQueries.insertUserInfo(
-      firstNameParam: UserDataConstants.user1FirstName,
-      lastNameParam: UserDataConstants.user1LastName,
+      firstName: UserDataConstants.user1FirstName,
+      lastName: UserDataConstants.user1LastName,
     );
     final res = await user1UserNameQueries.updateHasSentAnInvitation(true);
     final dupRes = await user1UserNameQueries.updateHasSentAnInvitation(true);
-    expect(res.first[UserNamesQueries.hasSentAnInvitation], true);
-    expect(dupRes.first[UserNamesQueries.hasSentAnInvitation], true);
+    expect(res.first[user1UserNameQueries.HAS_SENT_AN_INVITATION], true);
+    expect(dupRes.first[user1UserNameQueries.HAS_SENT_AN_INVITATION], true);
   });
 
   test(
       "should be able to update their `has_gone_through_invitation_flow` field",
       () async {
     await user1UserNameQueries.insertUserInfo(
-      firstNameParam: UserDataConstants.user1FirstName,
-      lastNameParam: UserDataConstants.user1LastName,
+      firstName: UserDataConstants.user1FirstName,
+      lastName: UserDataConstants.user1LastName,
     );
     final res =
         await user1UserNameQueries.updateHasGoneThroughInvitationFlow(true);
     final dupRes =
         await user1UserNameQueries.updateHasGoneThroughInvitationFlow(true);
-    expect(res.first[UserNamesQueries.hasGoneThroughInvitationFlow], true);
-    expect(dupRes.first[UserNamesQueries.hasGoneThroughInvitationFlow], true);
+    expect(
+        res.first[user1UserNameQueries.HAS_GONE_THROUGH_INVITATION_FLOW], true);
+    expect(dupRes.first[user1UserNameQueries.HAS_GONE_THROUGH_INVITATION_FLOW],
+        true);
   });
 
   test("should be able to update their `wants_to_repeat_invitation_flow` field",
       () async {
     await user1UserNameQueries.insertUserInfo(
-      firstNameParam: UserDataConstants.user1FirstName,
-      lastNameParam: UserDataConstants.user1LastName,
+      firstName: UserDataConstants.user1FirstName,
+      lastName: UserDataConstants.user1LastName,
     );
     final res =
         await user1UserNameQueries.updateWantsToRepeatInvitationFlow(true);
     final dupRes =
         await user1UserNameQueries.updateWantsToRepeatInvitationFlow(true);
-    expect(res.first[UserNamesQueries.wantsToRepeatInvitationFlow], true);
-    expect(dupRes.first[UserNamesQueries.wantsToRepeatInvitationFlow], true);
+    expect(
+        res.first[user1UserNameQueries.WANTS_TO_REPEAT_INVITATION_FLOW], true);
+    expect(dupRes.first[user1UserNameQueries.WANTS_TO_REPEAT_INVITATION_FLOW],
+        true);
   });
 
   test("❌ shouldn't be able to insert another row if they already have one",
       () async {
     await user1UserNameQueries.insertUserInfo(
-      firstNameParam: UserDataConstants.user1FirstName,
-      lastNameParam: UserDataConstants.user1LastName,
+      firstName: UserDataConstants.user1FirstName,
+      lastName: UserDataConstants.user1LastName,
     );
 
     try {
       await user1UserNameQueries.insertUserInfo(
-        firstNameParam: UserDataConstants.user1FirstName,
-        lastNameParam: UserDataConstants.user1LastName,
+        firstName: UserDataConstants.user1FirstName,
+        lastName: UserDataConstants.user1LastName,
       );
     } catch (e) {
       expect(e, isA<PostgrestException>());
@@ -108,8 +112,8 @@ void main() {
   test("❌ SHOULDN'T be able to enter a UID that isn't theirs", () async {
     try {
       await user1UserNameQueries.insertUserInfo(
-        firstNameParam: UserDataConstants.user1FirstName,
-        lastNameParam: UserDataConstants.user1LastName,
+        firstName: UserDataConstants.user1FirstName,
+        lastName: UserDataConstants.user1LastName,
       );
     } catch (e) {
       expect(e, isA<PostgrestException>());

--- a/packages/backend/dart/test/03_synchronous_search_test.dart
+++ b/packages/backend/dart/test/03_synchronous_search_test.dart
@@ -32,6 +32,10 @@ void main() {
 
   tearDownAll(() async {
     await tSetup.tearDownAll();
+    await tSetup.supabaseAdmin.from('active_nokhte_sessions').delete().eq(
+          "collaborator_uids",
+          [tSetup.thirdUserUID, tSetup.firstUserUID]..sort(),
+        );
     await user1EndEdgeFunctions.invoke();
     await user3EndEdgeFunctions.invoke();
   });

--- a/packages/backend/dart/test/10_active_nokhte_sessions_table_test.dart
+++ b/packages/backend/dart/test/10_active_nokhte_sessions_table_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: file_names
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nokhte_backend/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart';
 import 'package:nokhte_backend/tables/_real_time_enabled/active_nokhte_sessions/active_nohte_sessions.dart';
 import 'package:nokhte_backend/tables/_real_time_enabled/active_nokhte_sessions/types/nokhte_session_metadata.dart';
 
@@ -10,21 +11,30 @@ void main() {
   late ActiveNokhteSessionQueries user1Queries;
   late ActiveNokhteSessionQueries user2Queries;
   late ActiveNokhteSessionsStream user1Stream;
+  late FinishedNokhteSessionQueries user1FinishedQueries;
   final tSetup = CommonCollaborativeTestFunctions();
+  List sortedArr = [];
 
   setUpAll(() async {
     await tSetup.setUp(shouldMakeCollaboration: false);
+    sortedArr = [tSetup.firstUserUID, tSetup.secondUserUID]..sort();
     user1Queries = ActiveNokhteSessionQueries(supabase: tSetup.user1Supabase);
+    user1FinishedQueries =
+        FinishedNokhteSessionQueries(supabase: tSetup.user1Supabase);
     user1Stream = ActiveNokhteSessionsStream(supabase: tSetup.user1Supabase);
     user2Queries = ActiveNokhteSessionQueries(supabase: tSetup.user2Supabase);
   });
 
+  tearDownAll(() async {
+    await tSetup.supabaseAdmin
+        .from("finished_nokhte_sessions")
+        .delete()
+        .eq("collaborator_uids", sortedArr);
+  });
+
   test("select", () async {
-    await tSetup.supabaseAdmin.from("active_nokhte_sessions").insert({
-      "meeting_uid": tSetup.firstUserUID,
-      "collaborator_one_uid": tSetup.firstUserUID,
-      "collaborator_two_uid": tSetup.secondUserUID,
-    });
+    await tSetup.supabaseAdmin.from("active_nokhte_sessions").insert(
+        {"meeting_uid": tSetup.firstUserUID, "collaborator_uids": sortedArr});
     final res = await user1Queries.select();
     expect(res, isNotEmpty);
   });
@@ -57,6 +67,13 @@ void main() {
   test("getCurrentPhases", () async {
     final res = await user1Queries.getCurrentPhases();
     expect(res, [1, 1]);
+  });
+
+  test("getCreatedAt", () async {
+    final res = await user1Queries.getCreatedAt();
+    final parsed = DateTime.parse(res);
+    expect(res, isA<String>());
+    expect(parsed, isA<DateTime>());
   });
 
   test("updateOnlineStatus", () async {
@@ -102,8 +119,8 @@ void main() {
     expect(res, true);
   });
 
-  test("getSessionMetadata", () async {
-    final stream = user1Stream.getSessionMetadata();
+  test("getPresenceMetadata", () async {
+    final stream = user1Stream.getPresenceMetadata();
     expect(
       stream,
       emits(
@@ -119,9 +136,58 @@ void main() {
     );
   });
 
-  test("delete", () async {
-    await user1Queries.delete();
-    final res = await user1Queries.select();
-    expect(res, isEmpty);
+  test("composePath", () async {
+    final res = await user1Queries.composePath("test");
+    final timeStamp = await user1Queries.getCreatedAt();
+    expect(res.split('/')[0], "${tSetup.firstUserUID}_${tSetup.secondUserUID}");
+    expect(res.split('/')[1], timeStamp);
+    expect(res.split('/')[2], "test.wav");
+  });
+
+  test("addNewAudioClipToSeessionMetadata", () async {
+    await user1Queries.addNewAudioClipToSessionMetadata("test");
+    final res = await user1Queries.getSessionMetadata();
+    expect(res.first['audioID'], "test");
+    final indexRes = await user1Queries.getMetadataIndex();
+    expect(indexRes, 0);
+  });
+  test("updateCurentMetadataIndexContent", () async {
+    await user1Queries.updateCurrentMetadataIndexContent("test");
+    final res = await user1Queries.getSessionMetadata();
+    expect(res.first['content'], "test");
+  });
+
+  test("getAudioIds", () async {
+    final res = await user1Queries.getAudioIdPaths();
+    final firstPath = res.first;
+    final timeStamp = await user1Queries.getCreatedAt();
+    expect(firstPath.split('/')[0],
+        "${tSetup.firstUserUID}_${tSetup.secondUserUID}");
+    expect(firstPath.split('/')[1], timeStamp);
+    expect(firstPath.split('/')[2], "test.wav");
+  });
+
+  test("getAudioIdPaths", () async {
+    final res = await user1Queries.getAudioIdPaths();
+    final firstPath = res.first;
+    final timeStamp = await user1Queries.getCreatedAt();
+    expect(firstPath.split('/')[0],
+        "${tSetup.firstUserUID}_${tSetup.secondUserUID}");
+    expect(firstPath.split('/')[1], timeStamp);
+    expect(firstPath.split('/')[2], "test.wav");
+  });
+
+  test("completeSession", () async {
+    final sessionTimestamp = await user1Queries.getCreatedAt();
+    await user1Queries.completeSession();
+    final res = await user1FinishedQueries.select();
+    expect(res.first["session_metadata"], [
+      {
+        "audioID": "test",
+        "content": "test",
+      }
+    ]);
+    expect(res.first["collaborator_uids"], sortedArr);
+    expect(res.first["session_timestamp"], sessionTimestamp);
   });
 }

--- a/packages/backend/dart/test/10_active_nokhte_sessions_table_test.dart
+++ b/packages/backend/dart/test/10_active_nokhte_sessions_table_test.dart
@@ -46,12 +46,12 @@ void main() {
 
   test("GetCollaboratorOne", () async {
     final res = await user1Queries.getCollaboratorOne();
-    expect(res, tSetup.firstUserUID);
+    expect(res, sortedArr[0]);
   });
 
   test("getCollaboratorTwo", () async {
     final res = await user1Queries.getCollaboratorTwo();
-    expect(res, tSetup.secondUserUID);
+    expect(res, sortedArr[1]);
   });
 
   test("getWhoIsOnline", () async {
@@ -139,7 +139,7 @@ void main() {
   test("composePath", () async {
     final res = await user1Queries.composePath("test");
     final timeStamp = await user1Queries.getCreatedAt();
-    expect(res.split('/')[0], "${tSetup.firstUserUID}_${tSetup.secondUserUID}");
+    expect(res.split('/')[0], "${sortedArr[0]}_${sortedArr[1]}");
     expect(res.split('/')[1], timeStamp);
     expect(res.split('/')[2], "test.wav");
   });

--- a/packages/backend/dart/test/12_finished_nokhte_sessions_table_test.dart
+++ b/packages/backend/dart/test/12_finished_nokhte_sessions_table_test.dart
@@ -8,6 +8,18 @@ import 'shared/shared.dart';
 void main() {
   late FinishedNokhteSessionQueries user1Queries;
   final tSetup = CommonCollaborativeTestFunctions();
+  late List<String> sortedUIDs;
+  final tSessionMetadata = [
+    {"audioID": "s1t1", "content": "s1t1"},
+    {"audioID": "s1t2", "content": "s1t2"},
+    {"audioID": "s1t3", "content": "s1t3"},
+  ];
+  final t2SessionMetadata = [
+    {"audioID": "s2t1", "content": "s2t1"},
+    {"audioID": "s2t2", "content": "s2t2"},
+    {"audioID": "s2t3", "content": "s2t3"},
+  ];
+  final now = DateTime.now().toIso8601String();
 
   setUpAll(() async {
     await tSetup.setUp(shouldMakeCollaboration: false);
@@ -15,25 +27,61 @@ void main() {
   });
 
   tearDownAll(() async {
-    await tSetup.supabaseAdmin
-        .from("finished_nokhte_sessions")
-        .delete()
-        .eq("collaborator_one_uid", tSetup.firstUserUID);
+    await tSetup.supabaseAdmin.from('finished_nokhte_sessions').delete().eq(
+          FinishedNokhteSessionQueries.COLLABORATOR_UIDS,
+          [tSetup.firstUserUID, tSetup.secondUserUID]..sort(),
+        );
+    await tSetup.supabaseAdmin.from('finished_nokhte_sessions').delete().eq(
+          FinishedNokhteSessionQueries.COLLABORATOR_UIDS,
+          [tSetup.firstUserUID, tSetup.thirdUserUID]..sort(),
+        );
   });
 
   test("insert", () async {
+    sortedUIDs = [tSetup.firstUserUID, tSetup.secondUserUID]..sort();
     final res = await user1Queries.insert(
-      collaboratorOneUID: tSetup.firstUserUID,
-      collaboratorTwoUID: tSetup.secondUserUID,
+      collaboratorUIDs: sortedUIDs,
+      sessionMetadata: tSessionMetadata,
+      sessionTimestamp: now,
     );
-    expect(res, isNotEmpty);
+    expect(
+        res.first[FinishedNokhteSessionQueries.COLLABORATOR_UIDS], sortedUIDs);
+    expect(res.first[FinishedNokhteSessionQueries.SESSION_METADATA],
+        tSessionMetadata);
   });
 
   test("select", () async {
-    final res = await user1Queries.select(
-      collaboratorOneUID: tSetup.firstUserUID,
-      collaboratorTwoUID: tSetup.secondUserUID,
-    );
+    final res = await user1Queries.select();
     expect(res, isNotEmpty);
+  });
+
+  test("selectByCollaborationId", () async {
+    final user1And3 = [tSetup.firstUserUID, tSetup.thirdUserUID]..sort();
+    await user1Queries.insert(
+      collaboratorUIDs: user1And3,
+      sessionMetadata: tSessionMetadata,
+      sessionTimestamp: now,
+    );
+    final res = await user1Queries.selectByCollaborationId(tSetup.thirdUserUID);
+    expect(
+        res.first[FinishedNokhteSessionQueries.COLLABORATOR_UIDS], user1And3);
+  });
+
+  test("getAudioPathsFromSession", () async {
+    await user1Queries.insert(
+      collaboratorUIDs: sortedUIDs,
+      sessionMetadata: t2SessionMetadata,
+      sessionTimestamp: now,
+    );
+    final session1res =
+        await user1Queries.getAudioPathsFromSession(tSetup.secondUserUID, 0);
+    expect(session1res.first, contains('s1t1.wav'));
+    expect(session1res[1], contains('s1t2.wav'));
+    expect(session1res[2], contains('s1t3.wav'));
+    final session2res =
+        await user1Queries.getAudioPathsFromSession(tSetup.secondUserUID, 1);
+    expect(session2res.first, contains('s2t1.wav'));
+    expect(session2res[1], contains('s2t2.wav'));
+    expect(session2res[2], contains('s2t3.wav'));
   });
 }

--- a/packages/backend/dart/test/13_nokhte_sessions_audio_bucket_test.dart
+++ b/packages/backend/dart/test/13_nokhte_sessions_audio_bucket_test.dart
@@ -1,0 +1,67 @@
+// ignore_for_file: file_names
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nokhte_backend/storage/buckets/nokhte_sessions_audio/nokhte_sessions_audio_storage_queries.dart';
+import 'package:nokhte_backend/storage/buckets/nokhte_sessions_audio/types/types.dart';
+import 'package:nokhte_backend/tables/_real_time_disabled/finished_nokhte_sessions/queries.dart';
+import 'package:nokhte_backend/tables/active_nokhte_sessions.dart';
+import 'shared/common_collaborative_test_functions.dart';
+
+void main() {
+  late NokhteSessionsAudioStorageQueries user1Storage;
+  late FinishedNokhteSessionQueries user1FinishedQueries;
+  late ActiveNokhteSessionQueries user1ActiveQueries;
+  final tSetup = CommonCollaborativeTestFunctions();
+  setUpAll(() async {
+    await tSetup.setUp(shouldMakeCollaboration: false);
+    user1Storage = NokhteSessionsAudioStorageQueries(
+      supabase: tSetup.user1Supabase,
+    );
+    user1FinishedQueries = FinishedNokhteSessionQueries(
+      supabase: tSetup.user1Supabase,
+    );
+    user1ActiveQueries = ActiveNokhteSessionQueries(
+      supabase: tSetup.user1Supabase,
+    );
+  });
+
+  tearDownAll(() async {
+    final tableNames = ["finished_nokhte_sessions", "active_nokhte_sessions"];
+    await user1Storage.nuke(collaboratorUID: tSetup.secondUserUID);
+    for (var table in tableNames) {
+      await tSetup.supabaseAdmin.from(table).delete().eq(
+            FinishedNokhteSessionQueries.COLLABORATOR_UIDS,
+            [tSetup.firstUserUID, tSetup.secondUserUID]..sort(),
+          );
+    }
+  });
+
+  test("upload", () async {
+    final sorted = [tSetup.firstUserUID, tSetup.secondUserUID]..sort();
+    await tSetup.supabaseAdmin.from("active_nokhte_sessions").insert(
+        {"collaborator_uids": sorted, "meeting_uid": tSetup.firstUserUID});
+    final timeStamp = await user1ActiveQueries.getCreatedAt();
+    await user1FinishedQueries.insert(
+      collaboratorUIDs: sorted,
+      sessionMetadata: [
+        {"audioID": "s1t1", "content": "s1t1"},
+      ],
+      sessionTimestamp: timeStamp,
+    );
+    final file = File('${Directory.current.path}/test/assets/star_wars.wav');
+    await user1Storage
+        .upload(UploadNokhteSessionAudioParams(audioID: 's1t1', file: file));
+    final url = await user1Storage.supabase.storage
+        .from(user1Storage.BUCKET)
+        .createSignedUrl('/${sorted.join('_')}/$timeStamp/s1t1.wav', 3600);
+    expect(url, isNotEmpty);
+  });
+
+  test("download", () async {
+    final res = await user1Storage.download(
+        collaboratorUID: tSetup.secondUserUID, sessionIndex: 0);
+    expect(res, isNotEmpty);
+  });
+}

--- a/packages/backend/dart/test/shared/common_collaborative_test_functions.dart
+++ b/packages/backend/dart/test/shared/common_collaborative_test_functions.dart
@@ -67,14 +67,6 @@ class CommonCollaborativeTestFunctions {
         user1PerspectivesQueries.collaboratorInfo;
     if (shouldTeardownCollaboration) {
       await existingCollaborationsQueries.deleteExistingCollaboration();
-      await supabaseAdmin
-          .from('active_nokhte_sessions')
-          .delete()
-          .contains('collaborator_uids', firstUserUID);
-      await supabaseAdmin
-          .from('finished_nokhte_sessions')
-          .delete()
-          .contains('collaborator_uids', firstUserUID);
       await supabaseAdmin.from('existing_collaborations').delete().or(
             'collaborator_one.eq.$firstUserUID,collaborator_two.eq.$firstUserUID,collaborator_one.eq.$secondUserUID,collaborator_two.eq.$secondUserUID,collaborator_one.eq.$thirdUserUID,collaborator_two.eq.$thirdUserUID',
           );

--- a/packages/backend/dart/test/shared/common_collaborative_test_functions.dart
+++ b/packages/backend/dart/test/shared/common_collaborative_test_functions.dart
@@ -67,10 +67,17 @@ class CommonCollaborativeTestFunctions {
         user1PerspectivesQueries.collaboratorInfo;
     if (shouldTeardownCollaboration) {
       await existingCollaborationsQueries.deleteExistingCollaboration();
-      await supabaseAdmin.from('active_nokhte_sessions').delete().or(
-          'collaborator_one_uid.eq.$firstUserUID,collaborator_two_uid.eq.$firstUserUID,collaborator_one_uid.eq.$secondUserUID,collaborator_two_uid.eq.$secondUserUID,collaborator_one_uid.eq.$thirdUserUID,collaborator_two_uid.eq.$thirdUserUID');
+      await supabaseAdmin
+          .from('active_nokhte_sessions')
+          .delete()
+          .contains('collaborator_uids', firstUserUID);
+      await supabaseAdmin
+          .from('finished_nokhte_sessions')
+          .delete()
+          .contains('collaborator_uids', firstUserUID);
       await supabaseAdmin.from('existing_collaborations').delete().or(
-          'collaborator_one.eq.$firstUserUID,collaborator_two.eq.$firstUserUID,collaborator_one.eq.$secondUserUID,collaborator_two.eq.$secondUserUID,collaborator_one.eq.$thirdUserUID,collaborator_two.eq.$thirdUserUID');
+            'collaborator_one.eq.$firstUserUID,collaborator_two.eq.$firstUserUID,collaborator_one.eq.$secondUserUID,collaborator_two.eq.$secondUserUID,collaborator_one.eq.$thirdUserUID,collaborator_two.eq.$thirdUserUID',
+          );
     }
 
     if (shouldTearDownPerspectives) {

--- a/packages/backend/supabase/functions/initiate-collaborator-search/update_authorized_viewers.ts
+++ b/packages/backend/supabase/functions/initiate-collaborator-search/update_authorized_viewers.ts
@@ -1,0 +1,28 @@
+import { supabaseAdmin } from "../constants/supabase.ts";
+
+async function updateAuthorizedViewers(matchedUID: string, userUID: string) {
+  const userAuthorizedViewersRes: Array<string> = (
+    await supabaseAdmin.from("user_names").select().eq("uid", userUID)
+  ).data?.[0]["authorized_viewers"];
+  if (userAuthorizedViewersRes.includes(matchedUID)) return;
+  userAuthorizedViewersRes.push(matchedUID);
+  const collaboratorRowRes: Array<string> = (
+    await supabaseAdmin.from("user_names").select().eq("uid", matchedUID)
+  ).data?.[0]["authorized_viewers"];
+  if (collaboratorRowRes.includes(userUID)) return;
+  collaboratorRowRes.push(userUID);
+  await supabaseAdmin
+    .from("user_names")
+    .update({
+      authorized_viewers: userAuthorizedViewersRes,
+    })
+    .eq("uid", userUID);
+  await supabaseAdmin
+    .from("user_names")
+    .update({
+      authorized_viewers: collaboratorRowRes,
+    })
+    .eq("uid", matchedUID);
+}
+
+export { updateAuthorizedViewers };

--- a/packages/backend/supabase/migrations/20240204182700_nokhte_session_metadata_additions.sql
+++ b/packages/backend/supabase/migrations/20240204182700_nokhte_session_metadata_additions.sql
@@ -1,0 +1,4 @@
+alter table "public"."active_nokhte_sessions" add column "session_metadata" jsonb[] not null default '{}'::jsonb[];
+
+alter table "public"."active_nokhte_sessions" alter column "is_online" set not null;
+

--- a/packages/backend/supabase/migrations/20240205222739_nokhte_session_audio_storage_storage_additions.sql
+++ b/packages/backend/supabase/migrations/20240205222739_nokhte_session_audio_storage_storage_additions.sql
@@ -1,0 +1,36 @@
+insert into storage.buckets (id, name)
+    values  ('nokhte-sessions-audio', 'nokhte-sessions-audio');
+
+create policy "users can delete in nokhte-sessions-audio"
+on "storage"."objects"
+as permissive
+for delete
+to authenticated
+using ((((bucket_id = 'nokhte-sessions-audio'::text) AND ((split_part((storage.foldername(name))[1], '_'::text, 1) = (auth.uid())::text) OR (split_part((storage.foldername(name))[1], '_'::text, 2) = (auth.uid())::text))) OR ((bucket_id = 'nokhte-sessions-audio'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text))));
+
+
+create policy "users can insert in nokhte-sessions-audio"
+on "storage"."objects"
+as permissive
+for insert
+to authenticated
+with check ((((bucket_id = 'nokhte-sessions-audio'::text) AND ((split_part((storage.foldername(name))[1], '_'::text, 1) = (auth.uid())::text) OR (split_part((storage.foldername(name))[1], '_'::text, 2) = (auth.uid())::text))) OR ((bucket_id = 'nokhte-sessions-audio'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text))));
+
+
+create policy "users can select in nokhte-sessions-audio"
+on "storage"."objects"
+as permissive
+for select
+to authenticated
+using ((((bucket_id = 'nokhte-sessions-audio'::text) AND ((split_part((storage.foldername(name))[1], '_'::text, 1) = (auth.uid())::text) OR (split_part((storage.foldername(name))[1], '_'::text, 2) = (auth.uid())::text))) OR ((bucket_id = 'nokhte-sessions-audio'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text))));
+
+
+create policy "users can update in nokhte-sessions-audio "
+on "storage"."objects"
+as permissive
+for update
+to authenticated
+using ((((bucket_id = 'nokhte-sessions-audio'::text) AND ((split_part((storage.foldername(name))[1], '_'::text, 1) = (auth.uid())::text) OR (split_part((storage.foldername(name))[1], '_'::text, 2) = (auth.uid())::text))) OR ((bucket_id = 'nokhte-sessions-audio'::text) AND ((storage.foldername(name))[1] = (auth.uid())::text))));
+
+
+

--- a/packages/backend/supabase/migrations/20240205223218_add_columns_to_active_and_finished_nokhte_sessions.sql
+++ b/packages/backend/supabase/migrations/20240205223218_add_columns_to_active_and_finished_nokhte_sessions.sql
@@ -1,0 +1,10 @@
+alter table "public"."active_nokhte_sessions" add column "metadata_index" smallint not null default '0'::smallint;
+
+alter table "public"."active_nokhte_sessions" alter column "current_phases" set default '{1,1}'::real[];
+
+alter table "public"."active_nokhte_sessions" alter column "current_phases" set data type real[] using "current_phases"::real[];
+
+alter table "public"."finished_nokhte_sessions" add column "session_metadata" jsonb[] not null;
+
+alter table "public"."finished_nokhte_sessions" add column "session_timestamp" timestamp with time zone not null;
+

--- a/packages/backend/supabase/migrations/20240205223348_refactor_to_collaborator_uids_rls_and_all.sql
+++ b/packages/backend/supabase/migrations/20240205223348_refactor_to_collaborator_uids_rls_and_all.sql
@@ -1,0 +1,75 @@
+drop policy "READ: People Can Only Read Their Own Row" on "public"."user_names";
+
+drop policy "DELETE: they can delete their row" on "public"."active_nokhte_sessions";
+
+drop policy "SELECT: They can read their row" on "public"."active_nokhte_sessions";
+
+drop policy "UPDATE: They can only update their row" on "public"."active_nokhte_sessions";
+
+drop policy "SELECT: Users can read their past Nokhte Sessions" on "public"."finished_nokhte_sessions";
+
+alter table "public"."active_nokhte_sessions" drop constraint "active_nokhte_sessions_collaborator_one_uid_fkey";
+
+alter table "public"."active_nokhte_sessions" drop constraint "active_nokhte_sessions_collaborator_two_uid_fkey";
+
+alter table "public"."finished_nokhte_sessions" drop constraint "finished_nokhte_sessions_collaborator_one_uid_fkey";
+
+alter table "public"."finished_nokhte_sessions" drop constraint "finished_nokhte_sessions_collaborator_two_uid_fkey";
+
+alter table "public"."active_nokhte_sessions" drop column "collaborator_one_uid";
+
+alter table "public"."active_nokhte_sessions" drop column "collaborator_two_uid";
+
+alter table "public"."active_nokhte_sessions" add column "collaborator_uids" uuid[] not null;
+
+alter table "public"."finished_nokhte_sessions" drop column "collaborator_one_uid";
+
+alter table "public"."finished_nokhte_sessions" drop column "collaborator_two_uid";
+
+alter table "public"."finished_nokhte_sessions" add column "collaborator_uids" uuid[] not null;
+
+alter table "public"."user_names" add column "authorized_viewers" uuid[] not null default '{}'::uuid[];
+
+CREATE UNIQUE INDEX active_nokhte_sessions_collaborator_uids_key ON public.active_nokhte_sessions USING btree (collaborator_uids);
+
+alter table "public"."active_nokhte_sessions" add constraint "active_nokhte_sessions_collaborator_uids_key" UNIQUE using index "active_nokhte_sessions_collaborator_uids_key";
+
+create policy "Can Read: If Is An Authorized Viewer Or Owner"
+on "public"."user_names"
+as permissive
+for select
+to authenticated
+using (((uid = auth.uid()) OR (auth.uid() = ANY (authorized_viewers))));
+
+
+create policy "DELETE: they can delete their row"
+on "public"."active_nokhte_sessions"
+as permissive
+for delete
+to authenticated
+using ((auth.uid() = ANY (collaborator_uids)));
+
+
+create policy "SELECT: They can read their row"
+on "public"."active_nokhte_sessions"
+as permissive
+for select
+to authenticated
+using ((auth.uid() = ANY (collaborator_uids)));
+
+
+create policy "UPDATE: They can only update their row"
+on "public"."active_nokhte_sessions"
+as permissive
+for update
+to authenticated
+using ((auth.uid() = ANY (collaborator_uids)))
+with check ((auth.uid() = ANY (collaborator_uids)));
+
+
+create policy "SELECT: Users can read their past Nokhte Sessions"
+on "public"."finished_nokhte_sessions"
+as permissive
+for select
+to authenticated
+using ((auth.uid() = ANY (collaborator_uids)));

--- a/packages/client/lib/app/core/modules/deep_links/data/sources/deep_links_remote_source.dart
+++ b/packages/client/lib/app/core/modules/deep_links/data/sources/deep_links_remote_source.dart
@@ -49,7 +49,7 @@ class DeepLinksRemoteSourceImpl implements DeepLinksRemoteSource {
       _assembleCollaboratorInvitation() async {
     final uid = supabase.auth.currentUser?.id ?? '';
     final firstName =
-        (await userNames.getUserInfo()).first[UserNamesQueries.firstName];
+        (await userNames.getUserInfo()).first[userNames.FIRST_NAME];
     return CollaboratorInvitationInformation(
       firstName: firstName,
       uid: uid,

--- a/packages/client/lib/app/core/modules/presence_modules/nokhte_session_presence/data/nokhte_session_presence_remote_source.dart
+++ b/packages/client/lib/app/core/modules/presence_modules/nokhte_session_presence/data/nokhte_session_presence_remote_source.dart
@@ -19,7 +19,7 @@ class NokhteSessionPresenceRemoteSourceImpl
   clearTheCurrentTalker() async => await queries.clearTheCurrentTalker();
 
   @override
-  getSessionMetadata() => stream.getSessionMetadata();
+  getSessionMetadata() => stream.getPresenceMetadata();
 
   @override
   setUserAsCurrentTalker() async => await queries.setUserAsTheCurrentTalker();

--- a/packages/client/lib/app/core/modules/user_information/data/models/user_journey_info_model.dart
+++ b/packages/client/lib/app/core/modules/user_information/data/models/user_journey_info_model.dart
@@ -1,5 +1,4 @@
 import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
-import 'package:nokhte_backend/tables/user_names.dart';
 
 class UserJourneyInfoModel extends UserJourneyInfoEntity {
   const UserJourneyInfoModel({
@@ -19,12 +18,12 @@ class UserJourneyInfoModel extends UserJourneyInfoEntity {
       );
     } else {
       return UserJourneyInfoModel(
-        userUID: res.first[UserNamesQueries.uid],
+        userUID: res.first['uid'],
         hasGoneThroughInvitationFlow:
-            res.first[UserNamesQueries.hasGoneThroughInvitationFlow],
-        hasSentAnInvitation: res.first[UserNamesQueries.hasSentAnInvitation],
+            res.first['has_gone_through_invitation_flow'],
+        hasSentAnInvitation: res.first['has_sent_an_invitation'],
         wantsToRepeatInvitationFlow:
-            res.first[UserNamesQueries.wantsToRepeatInvitationFlow],
+            res.first['wants_to_repeat_invitation_flow'],
       );
     }
   }

--- a/packages/client/lib/app/modules/home/data/sources/home_remote_source.dart
+++ b/packages/client/lib/app/modules/home/data/sources/home_remote_source.dart
@@ -49,8 +49,8 @@ class HomeRemoteSourceImpl implements HomeRemoteSource {
       final [firstName, lastName] = MiscAlgos.returnSplitName(fullName);
 
       insertRes = await userNamesQueries.insertUserInfo(
-        firstNameParam: firstName,
-        lastNameParam: lastName,
+        firstName: firstName,
+        lastName: lastName,
       );
     } else {
       insertRes = [];


### PR DESCRIPTION
# New Stuff:
1. `nokhte-session-audio-storage` + associated queries & migrations & rls
2. `active-nokhte-session migrations` & queries to associate audio clips to given messages of text together
3. `finished_nokhte_sessions` migrations & queries.
4. the connective tissue between `active_nokhte_sessions`, `finished_nokhte_sessions` and `nokhte-session-audio-storage` to make them work as a cohesive whole for uploading audio, associating them to a certain piece of text, and then when the session is complete moving them over to `finished_nokhte_sessions` and have them be retrievable based on the session_metadata.
5. the ability to read people's `user_names` row if they are an approved reader, and the inclusion of this in the `is_nokhte_invitation` helper edge function that if they have at least started a session they are an approved reader of eachother's names in the database
6. the associated query to read their collaborators row in the user_names table

# Breaking Changes
1. the big one is the movement away from `collaborator_one_uid` and `collaborator_two_id` as far as identifying people in `nokhte_sessions` both `active` and `finished`, in favor of `collaborator_uids` which lists the uids in a sorted array which:
      1. is a viable database structure that even has the possibility of scaling to collaborations that are `>2` people, given in the past appraoch you would have to create a new column and have to re-do a bunch of logic just to add an extra person
2. naming conventions for constants in various query files which includes the queries & possibly streams associated with `user_names` `active_nokthe_sessions`, &  `finished_nokhte_sessions`     
