### PR TITLE
v1 patches: home screen split

### DIFF
--- a/packages/client/lib/app/core/modules/deep_links/mobx/main/listen_for_opened_deep_link_store.dart
+++ b/packages/client/lib/app/core/modules/deep_links/mobx/main/listen_for_opened_deep_link_store.dart
@@ -61,8 +61,8 @@ abstract class _ListenForOpenedDeepLinkStoreBase extends Equatable with Store {
               usersUID: getUserInfo.entity.userUID,
             ),
           );
-          path = res.path;
           additionalMetadata = ObservableMap.of(res.additionalMetadata);
+          path = res.path;
         }
       }
     });

--- a/packages/client/lib/app/core/modules/user_information/domain/contracts/user_information_contract.dart
+++ b/packages/client/lib/app/core/modules/user_information/domain/contracts/user_information_contract.dart
@@ -1,10 +1,8 @@
 import 'package:dartz/dartz.dart';
 import 'package:nokhte/app/core/error/failure.dart';
-import 'package:nokhte/app/core/interfaces/logic.dart';
-import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
+import 'package:nokhte/app/core/modules/user_information/shared/base_get_user_info_contract.dart';
 
-abstract class UserInformationContract {
-  Future<Either<Failure, UserJourneyInfoEntity>> getUserInfo(NoParams params);
+abstract class UserInformationContract extends BaseGetUserInfoContract {
   Future<Either<Failure, bool>> updateHasSentAnInvitation(
       bool hasSentAnInvitationParam);
   Future<Either<Failure, bool>> updateHasGoneThroughInvitationFlow(

--- a/packages/client/lib/app/core/modules/user_information/domain/logic/get_user_info.dart
+++ b/packages/client/lib/app/core/modules/user_information/domain/logic/get_user_info.dart
@@ -1,11 +1,10 @@
 import 'package:nokhte/app/core/interfaces/logic.dart';
 import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
+import 'package:nokhte/app/core/modules/user_information/shared/base_get_user_info.dart';
 
-class GetUserInfo
+class GetUserInfo extends BaseGetUserInfo<UserInformationContract>
     implements AbstractFutureLogic<UserJourneyInfoEntity, NoParams> {
-  final UserInformationContract contract;
-
-  GetUserInfo({required this.contract});
+  GetUserInfo({required super.contract});
 
   @override
   call(params) async => await contract.getUserInfo(params);

--- a/packages/client/lib/app/core/modules/user_information/mobx/main/get_user_info_store.dart
+++ b/packages/client/lib/app/core/modules/user_information/mobx/main/get_user_info_store.dart
@@ -4,6 +4,7 @@ import 'package:mobx/mobx.dart';
 import 'package:nokhte/app/core/interfaces/logic.dart';
 import 'package:nokhte/app/core/mobx/mobx.dart';
 import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
+import 'package:nokhte/app/core/modules/user_information/shared/shared.dart';
 part 'get_user_info_store.g.dart';
 
 class GetUserInfoStore = _GetUserInfoStoreBase with _$GetUserInfoStore;
@@ -28,7 +29,7 @@ abstract class _GetUserInfoStoreBase
   @observable
   UserJourneyInfoEntity entity = UserJourneyInfoEntity.initial();
 
-  final GetUserInfo logic;
+  final BaseGetUserInfo logic;
   _GetUserInfoStoreBase({required this.logic});
 
   @observable

--- a/packages/client/lib/app/core/modules/user_information/shared/base_get_user_info.dart
+++ b/packages/client/lib/app/core/modules/user_information/shared/base_get_user_info.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
+
+class BaseGetUserInfo<T>
+    implements AbstractFutureLogic<UserJourneyInfoEntity, NoParams> {
+  final T contract;
+
+  BaseGetUserInfo({required this.contract});
+
+  @override
+  call(NoParams params) async {
+    return Right(UserJourneyInfoEntity.initial());
+  }
+}

--- a/packages/client/lib/app/core/modules/user_information/shared/base_get_user_info_contract.dart
+++ b/packages/client/lib/app/core/modules/user_information/shared/base_get_user_info_contract.dart
@@ -1,0 +1,8 @@
+import 'package:dartz/dartz.dart';
+import 'package:nokhte/app/core/error/failure.dart';
+import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/modules/user_information/domain/domain.dart';
+
+abstract class BaseGetUserInfoContract {
+  Future<Either<Failure, UserJourneyInfoEntity>> getUserInfo(NoParams params);
+}

--- a/packages/client/lib/app/core/modules/user_information/shared/shared.dart
+++ b/packages/client/lib/app/core/modules/user_information/shared/shared.dart
@@ -1,0 +1,2 @@
+export "base_get_user_info.dart";
+export "base_get_user_info_contract.dart";

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/beach_waves_store.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/beach_waves_store.dart
@@ -23,6 +23,8 @@ abstract class _BeachWavesStoreBase extends Equatable with Store {
   final OnShoreMovieStore onShoreMovieStore = OnShoreMovieStore();
   final OnShoreToVibrantBlueMovieStore onShoreToVibrantBlueMovieStore =
       OnShoreToVibrantBlueMovieStore();
+  final ResumeOnShoreMovieStore resumeOnShoreMovieStore =
+      ResumeOnShoreMovieStore();
   final SuspendedAtOceanDiveStore suspendedAtOceanDiveStore =
       SuspendedAtOceanDiveStore();
   final SuspendedAtTheDepthsMovieStore suspendedAtTheDepthsMovieStore =
@@ -71,6 +73,7 @@ abstract class _BeachWavesStoreBase extends Equatable with Store {
           timesUpEndToTheDepthsMovieStore,
       BeachWaveMovieModes.timesUpEndToTimesUpStart:
           timesUpEndToTimesUpStartMovieStore,
+      BeachWaveMovieModes.resumeOnShore: resumeOnShoreMovieStore,
       BeachWaveMovieModes.timesUpEndToOceanDive: timesUpEndToOceanDiveMovie,
       BeachWaveMovieModes.suspendedAtOceanDive: suspendedAtOceanDiveStore,
       BeachWaveMovieModes.suspendedAtTheDepths: suspendedAtTheDepthsMovieStore,

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/movie_stores.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/movie_stores.dart
@@ -8,6 +8,7 @@ export 'on_shore_to_ocean_dive/on_shore_to_ocean_dive.dart';
 export 'times_up/times_up.dart';
 export 'times_up_dynamic_point_to_the_depths/times_up_dynamic_point_to_the_depths.dart';
 export "times_up_dynamic_point_to_times_up_start/times_up_dynamic_point_to_times_up_start.dart";
+export 'resume_on_shore/resume_on_shore.dart';
 export 'suspended_at_ocean_dive/suspended_at_ocean_dive.dart';
 export 'suspended_at_the_depths/suspended_at_the_depths.dart';
 export 'suspended_at_the_depths_to_times_up_start/suspended_at_the_depths_to_times_up_start.dart';

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore.dart
@@ -1,0 +1,3 @@
+export 'resume_on_shore_movie.dart';
+export 'resume_on_shore_movie_store.dart';
+export "resume_on_shore_params.dart";

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_movie.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_movie.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:simple_animations/simple_animations.dart';
+import 'package:nokhte/app/core/widgets/beach_widgets/shared/shared.dart';
+
+class ResumeOnShoreMovie {
+  static bool get shouldPaintSand => true;
+  static MovieTween getMovie(ResumeOnShoreParams params) => MovieTween()
+    ..scene(
+      begin: Seconds.get(0),
+      end: calculateDuration(params),
+    )
+        .tween(
+          BeachWaveAnimationKeys.waterMovement,
+          Tween<double>(
+            begin: params.position,
+            end: params.direction == WaterDirection.up ? -10.0 : 15.0,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color1,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater.first.color,
+            end: WaterColorsAndStops.onShoreWater.first.color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color2,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[1].color,
+            end: WaterColorsAndStops.onShoreWater[1].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color3,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[2].color,
+            end: WaterColorsAndStops.onShoreWater[2].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color4,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[3].color,
+            end: WaterColorsAndStops.onShoreWater[3].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color5,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[4].color,
+            end: WaterColorsAndStops.onShoreWater[4].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color6,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[5].color,
+            end: WaterColorsAndStops.onShoreWater[5].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color7,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[6].color,
+            end: WaterColorsAndStops.onShoreWater[6].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.color8,
+          ColorTween(
+            begin: WaterColorsAndStops.onShoreWater[7].color,
+            end: WaterColorsAndStops.onShoreWater[7].color,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop1,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater.first.stop,
+            end: WaterColorsAndStops.onShoreWater.first.stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop2,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[1].stop,
+            end: WaterColorsAndStops.onShoreWater[1].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop3,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[2].stop,
+            end: WaterColorsAndStops.onShoreWater[2].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop4,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[3].stop,
+            end: WaterColorsAndStops.onShoreWater[3].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop5,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[4].stop,
+            end: WaterColorsAndStops.onShoreWater[4].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop6,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[5].stop,
+            end: WaterColorsAndStops.onShoreWater[5].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop7,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[6].stop,
+            end: WaterColorsAndStops.onShoreWater[6].stop,
+          ),
+        )
+        .tween(
+          BeachWaveAnimationKeys.stop8,
+          Tween<double>(
+            begin: WaterColorsAndStops.onShoreWater[7].stop,
+            end: WaterColorsAndStops.onShoreWater[7].stop,
+          ),
+        );
+
+  static Duration calculateDuration(ResumeOnShoreParams params) {
+    double minValue = -10.0;
+    double maxValue = 15.0;
+
+    double totalDistance = maxValue - minValue;
+
+    double timeInSeconds = 2001 / 1000.0;
+
+    double speed = totalDistance / timeInSeconds;
+
+    double distanceFromStart;
+    if (params.direction == WaterDirection.up) {
+      distanceFromStart = params.position - minValue;
+    } else {
+      distanceFromStart = maxValue - params.position;
+    }
+
+    double durationInSeconds = distanceFromStart / speed;
+
+    int durationMillis = (durationInSeconds * 1000).round();
+
+    return Duration(milliseconds: durationMillis);
+  }
+}

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_movie_store.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_movie_store.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'resume_on_shore_movie_store.g.dart';
+
+class ResumeOnShoreMovieStore = _ResumeOnShoreMovieStoreBase
+    with _$ResumeOnShoreMovieStore;
+
+abstract class _ResumeOnShoreMovieStoreBase
+    extends BaseBeachWaveMovieStore<ResumeOnShoreParams> with Store {
+  _ResumeOnShoreMovieStoreBase()
+      : super(
+          callsOnCompleteTwice: false,
+          shouldPaintSand: OnShoreToVibrantBlue.shouldPaintSand,
+        ) {
+    movie = OnShoreMovie.movie;
+  }
+
+  @override
+  @action
+  initMovie(ResumeOnShoreParams params) {
+    setMovie(ResumeOnShoreMovie.getMovie(params));
+    setControl(Control.playFromStart);
+    setMovieStatus(MovieStatus.inProgress);
+  }
+}

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_params.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/presentation/mobx/movie_stores/resume_on_shore/resume_on_shore_params.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+
+class ResumeOnShoreParams extends Equatable {
+  final double position;
+  final WaterDirection direction;
+  const ResumeOnShoreParams({
+    required this.position,
+    required this.direction,
+  });
+
+  factory ResumeOnShoreParams.initial() => const ResumeOnShoreParams(
+        direction: WaterDirection.down,
+        position: -10.0,
+      );
+
+  @override
+  List<Object> get props => [position, direction];
+}

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/types/types.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/types/types.dart
@@ -1,2 +1,3 @@
 export './base_beach_wave_movie_store.dart';
 export "beach_wave_animation_keys.dart";
+export 'water_direction.dart';

--- a/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/types/water_direction.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/beach_waves/stack/types/water_direction.dart
@@ -1,0 +1,4 @@
+enum WaterDirection {
+  down,
+  up,
+}

--- a/packages/client/lib/app/core/widgets/beach_widgets/shared/types/beach_wave_movie_modes.dart
+++ b/packages/client/lib/app/core/widgets/beach_widgets/shared/types/beach_wave_movie_modes.dart
@@ -10,6 +10,7 @@ enum BeachWaveMovieModes {
   suspendedAtOceanDive,
   suspendedAtTheDepths,
   suspendedAtTheDepthsToTimesUpStart,
+  resumeOnShore,
   timesUp,
   timesUpDynamicPointToTheDepths,
   timesUpDynamicPointToTimesUpStart,

--- a/packages/client/lib/app/modules/authentication/authentication_module.dart
+++ b/packages/client/lib/app/modules/authentication/authentication_module.dart
@@ -1,10 +1,12 @@
 import 'package:nokhte/app/core/guards/auth_guard.dart';
 import 'package:nokhte/app/core/modules/legacy_connectivity/legacy_connectivity_module.dart';
+import 'package:nokhte/app/core/modules/user_information/mobx/mobx.dart';
 import 'package:nokhte/app/core/widgets/widget_modules/widget_modules.dart';
 import 'package:nokhte/app/core/widgets/widgets.dart';
 import 'package:nokhte/app/modules/authentication/authentication_widgets_module.dart';
 import 'package:nokhte/app/modules/authentication/domain/domain.dart';
 import 'package:nokhte/app/modules/authentication/data/data.dart';
+import 'package:nokhte/app/modules/authentication/domain/logic/auth_get_user_info.dart';
 import 'package:nokhte/app/modules/authentication/presentation/presentation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -36,6 +38,11 @@ class AuthenticationModule extends Module {
         contract: i.get<AuthenticationContractImpl>(),
       ),
     );
+    i.add<AuthGetUserInfo>(
+      () => AuthGetUserInfo(
+        contract: i.get<AuthenticationContractImpl>(),
+      ),
+    );
     i.add<GetAuthState>(
       () => GetAuthState(
         contract: i.get<AuthenticationContractImpl>(),
@@ -51,6 +58,11 @@ class AuthenticationModule extends Module {
         contract: i.get<AuthenticationContractImpl>(),
       ),
     );
+    i.add<GetUserInfoStore>(
+      () => GetUserInfoStore(
+        logic: i<AuthGetUserInfo>(),
+      ),
+    );
     i.add<SignInWithAuthProviderStore>(
       () => SignInWithAuthProviderStore(
         signInWithApple: i.get<SignInWithApple>(),
@@ -64,6 +76,7 @@ class AuthenticationModule extends Module {
     );
     i.add<LoginScreenCoordinator>(
       () => LoginScreenCoordinator(
+        getUserInfo: Modular.get<GetUserInfoStore>(),
         tap: Modular.get<TapDetector>(),
         swipe: Modular.get<SwipeDetector>(),
         addName: Modular.get<AddName>(),

--- a/packages/client/lib/app/modules/authentication/data/contracts/authentication_contract_impl.dart
+++ b/packages/client/lib/app/modules/authentication/data/contracts/authentication_contract_impl.dart
@@ -2,6 +2,7 @@ import 'package:dartz/dartz.dart';
 import 'package:nokhte/app/core/constants/failure_constants.dart';
 import 'package:nokhte/app/core/interfaces/logic.dart';
 import 'package:nokhte/app/core/mixins/response_to_status.dart';
+import 'package:nokhte/app/core/modules/user_information/data/data.dart';
 import 'package:nokhte/app/modules/authentication/domain/domain.dart';
 import 'package:nokhte/app/core/error/failure.dart';
 import 'package:nokhte/app/core/network/network_info.dart';
@@ -50,6 +51,16 @@ class AuthenticationContractImpl
     if (await networkInfo.isConnected) {
       final res = await remoteSource.addName();
       return Right(fromSupabase(res));
+    } else {
+      return Left(FailureConstants.internetConnectionFailure);
+    }
+  }
+
+  @override
+  getUserInfo(params) async {
+    if (await networkInfo.isConnected) {
+      final res = await remoteSource.getUserInfo();
+      return Right(UserJourneyInfoModel.fromSupabase(res));
     } else {
       return Left(FailureConstants.internetConnectionFailure);
     }

--- a/packages/client/lib/app/modules/authentication/data/sources/auth_remote_source.dart
+++ b/packages/client/lib/app/modules/authentication/data/sources/auth_remote_source.dart
@@ -1,3 +1,4 @@
+import 'package:nokhte/app/core/modules/user_information/data/data.dart';
 import 'package:nokhte/app/modules/authentication/data/models/models.dart';
 import 'package:nokhte/app/core/interfaces/auth_providers.dart';
 import 'package:nokhte_backend/tables/user_names.dart';
@@ -13,11 +14,13 @@ abstract class AuthenticationRemoteSource {
   Future<AuthProviderModel> signInWithApple();
   AuthStateModel getAuthState();
   Future<List> addName({String theName = ""});
+  Future<List> getUserInfo();
 }
 
 class AuthenticationRemoteSourceImpl implements AuthenticationRemoteSource {
   final SupabaseClient supabase;
   late UserNamesQueries queries;
+  late UserInformationRemoteSourceImpl userInfoRemoteSource;
 
   AuthenticationRemoteSourceImpl({required this.supabase})
       : queries = UserNamesQueries(supabase: supabase);
@@ -92,5 +95,11 @@ class AuthenticationRemoteSourceImpl implements AuthenticationRemoteSource {
       insertRes = [];
     }
     return nameCheck.isEmpty ? insertRes : nameCheck;
+  }
+
+  @override
+  Future<List> getUserInfo() async {
+    queries = UserNamesQueries(supabase: supabase);
+    return await queries.getUserInfo();
   }
 }

--- a/packages/client/lib/app/modules/authentication/domain/contracts/authentication_contract.dart
+++ b/packages/client/lib/app/modules/authentication/domain/contracts/authentication_contract.dart
@@ -1,9 +1,10 @@
 import 'package:dartz/dartz.dart';
 import 'package:nokhte/app/core/error/failure.dart';
 import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/modules/user_information/shared/base_get_user_info_contract.dart';
 import 'package:nokhte/app/modules/authentication/domain/entities/entities.dart';
 
-abstract class AuthenticationContract {
+abstract class AuthenticationContract extends BaseGetUserInfoContract {
   Future<Either<Failure, AuthProviderEntity>> googleSignIn(NoParams params);
 
   Future<Either<Failure, AuthProviderEntity>> appleSignIn(NoParams params);

--- a/packages/client/lib/app/modules/authentication/domain/logic/auth_get_user_info.dart
+++ b/packages/client/lib/app/modules/authentication/domain/logic/auth_get_user_info.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import 'package:nokhte/app/core/error/failure.dart';
+import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/modules/user_information/domain/entities/user_journey_info_entity.dart';
+import 'package:nokhte/app/core/modules/user_information/shared/base_get_user_info.dart';
+import 'package:nokhte/app/modules/authentication/domain/contracts/authentication_contract.dart';
+
+class AuthGetUserInfo extends BaseGetUserInfo<AuthenticationContract> {
+  AuthGetUserInfo({required super.contract});
+
+  @override
+  Future<Either<Failure, UserJourneyInfoEntity>> call(NoParams params) async =>
+      await contract.getUserInfo(params);
+}

--- a/packages/client/lib/app/modules/authentication/presentation/mobx/coordinators/login_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/authentication/presentation/mobx/coordinators/login_screen_coordinator.dart
@@ -2,25 +2,23 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 import 'package:nokhte/app/core/interfaces/auth_providers.dart';
 import 'package:nokhte/app/core/interfaces/logic.dart';
-import 'package:nokhte/app/core/mobx/mobx.dart';
-import 'package:nokhte/app/core/modules/user_information/mobx/mobx.dart';
 import 'package:nokhte/app/core/types/types.dart';
 import 'package:nokhte/app/core/widgets/widgets.dart';
 import 'package:nokhte/app/modules/authentication/domain/logic/logic.dart';
 import 'package:nokhte/app/modules/authentication/presentation/presentation.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_router_coordinator.dart';
 part 'login_screen_coordinator.g.dart';
 
 class LoginScreenCoordinator = _LoginScreenCoordinatorBase
     with _$LoginScreenCoordinator;
 
-abstract class _LoginScreenCoordinatorBase extends BaseCoordinator with Store {
+abstract class _LoginScreenCoordinatorBase
+    extends BaseHomeScreenRouterCoordinator with Store {
   final LoginScreenWidgetsCoordinator widgets;
   final SignInWithAuthProviderStore signInWithAuthProvider;
-  final GetUserInfoStore getUserInfo;
   final AddName addName;
   final GetAuthStateStore authStateStore;
   final SwipeDetector swipe;
@@ -31,7 +29,7 @@ abstract class _LoginScreenCoordinatorBase extends BaseCoordinator with Store {
     required this.widgets,
     required this.authStateStore,
     required this.addName,
-    required this.getUserInfo,
+    required super.getUserInfo,
     required this.tap,
     required this.swipe,
   });
@@ -71,7 +69,7 @@ abstract class _LoginScreenCoordinatorBase extends BaseCoordinator with Store {
     }, onDisconnected: () {
       setDisableAllTouchFeedback(true);
     });
-    widgets.layer2BeachWavesReactor(onHomeTransitionComplete);
+    widgets.layer2BeachWavesReactor(onAnimationComplete);
   }
 
   @action
@@ -85,18 +83,6 @@ abstract class _LoginScreenCoordinatorBase extends BaseCoordinator with Store {
   onDisconnected() {
     if (!disableAllTouchFeedback) {
       toggleDisableAllTouchFeedback();
-    }
-  }
-
-  onHomeTransitionComplete() {
-    final params = ResumeOnShoreParams.initial();
-    final args = {"resumeOnShoreParams": params};
-    if (!getUserInfo.hasGoneThroughInvitationFlow) {
-      Modular.to.navigate("/home/phase1", arguments: args);
-    } else if (getUserInfo.hasGoneThroughInvitationFlow) {
-      Modular.to.navigate("/home/phase2", arguments: args);
-    } else if (getUserInfo.hasDoneASession) {
-      Modular.to.navigate("/home/phase3", arguments: args);
     }
   }
 

--- a/packages/client/lib/app/modules/authentication/presentation/mobx/coordinators/login_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/authentication/presentation/mobx/coordinators/login_screen_widgets_coordinator.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: must_be_immutable, library_private_types_in_public_api
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:mobx/mobx.dart';
 import 'package:equatable/equatable.dart';
 import 'package:nokhte/app/core/interfaces/logic.dart';
@@ -178,7 +177,6 @@ abstract class _LoginScreenWidgetsCoordinatorBase extends Equatable with Store {
     nokhteReactor(loginBusinessLogic);
     trailingTextReactor();
     layer1BeachWavesReactor();
-    layer2BeachWavesReactor();
   }
 
   nokhteReactor(Function loginBusinessLogic) =>
@@ -219,7 +217,7 @@ abstract class _LoginScreenWidgetsCoordinatorBase extends Equatable with Store {
         }
       });
 
-  layer2BeachWavesReactor() =>
+  layer2BeachWavesReactor(Function onPt2Finished) =>
       reaction((p0) => layer2BeachWaves.movieStatus, (p0) {
         if (hasFinishedWaterFromTopPart1(p0)) {
           layer2BeachWaves.setMovieMode(
@@ -230,26 +228,10 @@ abstract class _LoginScreenWidgetsCoordinatorBase extends Equatable with Store {
           toggleHasCompletedWaterFromTopToOnShorePt1();
           layer2BeachWaves.currentStore.initMovie(NoParams());
         } else if (hasFinishedWaterFromTopPart2(p0)) {
-          Modular.to.navigate('/home/');
+          onPt2Finished();
+          // Modular.to.navigate('/home/');
         }
       });
-
-  // wifiDisconnectOverlayReactor() =>
-  //     reaction((p0) => wifiDisconnectOverlay.movieStatus, (p0) {
-  //       if (wifiDisconnectOverlay.movieMode ==
-  //           WifiDisconnectMovieModes.removeTheCircle) {
-  //         if (p0 == MovieStatus.inProgress && hasNotMadeTheDot) {
-  // smartTextStore.reset();
-  //         } else if (p0 == MovieStatus.finished) {
-  //           smartTextStore.resume();
-  //         }
-  //       } else if (wifiDisconnectOverlay.movieMode ==
-  //           WifiDisconnectMovieModes.placeTheCircle) {
-  //         if (p0 == MovieStatus.inProgress && hasNotMadeTheDot) {
-  //           smartTextStore.pause();
-  //         }
-  //       }
-  //     });
 
   hasFinishedBlackOutToSand(MovieStatus movieStatus) =>
       movieStatus == MovieStatus.finished &&

--- a/packages/client/lib/app/modules/collaboration/collaboration_logic_module.dart
+++ b/packages/client/lib/app/modules/collaboration/collaboration_logic_module.dart
@@ -15,7 +15,7 @@ class CollaborationLogicModule extends Module {
       ];
 
   @override
-  void binds(Injector i) {
+  void exportedBinds(Injector i) {
     i.add<CollaborationRemoteSourceImpl>(
       () => CollaborationRemoteSourceImpl(
         supabase: Modular.get<SupabaseClient>(),

--- a/packages/client/lib/app/modules/home/home_module.dart
+++ b/packages/client/lib/app/modules/home/home_module.dart
@@ -26,14 +26,36 @@ class HomeModule extends Module {
       ];
   @override
   binds(i) {
-    i.add<HomeScreenCoordinator>(
-      () => HomeScreenCoordinator(
+    i.add<Phase0HomeScreenCoordinator>(
+      () => Phase0HomeScreenCoordinator(
         deleteUnconsecratedCollaborations:
             Modular.get<DeleteUnconsecratedCollaborationsCoordinator>(),
-        userInformation: Modular.get<UserInformationCoordinator>(),
+        getUserInfo: Modular.get<GetUserInfoStore>(),
+        collaborationLogic: Modular.get<CollaborationLogicCoordinator>(),
+        widgets: Modular.get<Phase0HomeScreenWidgetsCoordinator>(),
+      ),
+    );
+    i.add<Phase1HomeScreenCoordinator>(
+      () => Phase1HomeScreenCoordinator(
         collaborationLogic: Modular.get<CollaborationLogicCoordinator>(),
         swipe: Modular.get<SwipeDetector>(),
-        widgets: Modular.get<HomeScreenWidgetsCoordinator>(),
+        widgets: Modular.get<Phase1HomeScreenWidgetsCoordinator>(),
+        deepLinks: Modular.get<DeepLinksCoordinator>(),
+      ),
+    );
+    i.add<Phase2HomeScreenCoordinator>(
+      () => Phase2HomeScreenCoordinator(
+        collaborationLogic: Modular.get<CollaborationLogicCoordinator>(),
+        swipe: Modular.get<SwipeDetector>(),
+        widgets: Modular.get<Phase2HomeScreenWidgetsCoordinator>(),
+        deepLinks: Modular.get<DeepLinksCoordinator>(),
+      ),
+    );
+    i.add<Phase3HomeScreenCoordinator>(
+      () => Phase3HomeScreenCoordinator(
+        collaborationLogic: Modular.get<CollaborationLogicCoordinator>(),
+        swipe: Modular.get<SwipeDetector>(),
+        widgets: Modular.get<Phase3HomeScreenWidgetsCoordinator>(),
         deepLinks: Modular.get<DeepLinksCoordinator>(),
       ),
     );
@@ -44,8 +66,29 @@ class HomeModule extends Module {
     r.child(
       "/",
       transition: TransitionType.noTransition,
-      child: (context) => HomeScreen(
-        coordinator: Modular.get<HomeScreenCoordinator>(),
+      child: (context) => Phase0HomeScreen(
+        coordinator: Modular.get<Phase0HomeScreenCoordinator>(),
+      ),
+    );
+    r.child(
+      "/phase1",
+      transition: TransitionType.noTransition,
+      child: (context) => Phase1HomeScreen(
+        coordinator: Modular.get<Phase1HomeScreenCoordinator>(),
+      ),
+    );
+    r.child(
+      "/phase2",
+      transition: TransitionType.noTransition,
+      child: (context) => Phase2HomeScreen(
+        coordinator: Modular.get<Phase2HomeScreenCoordinator>(),
+      ),
+    );
+    r.child(
+      "/phase3",
+      transition: TransitionType.noTransition,
+      child: (context) => Phase3HomeScreen(
+        coordinator: Modular.get<Phase3HomeScreenCoordinator>(),
       ),
     );
   }

--- a/packages/client/lib/app/modules/home/home_widgets_module.dart
+++ b/packages/client/lib/app/modules/home/home_widgets_module.dart
@@ -21,8 +21,33 @@ class HomeWidgetsModule extends Module {
     i.add<NokhteBlurStore>(
       () => NokhteBlurStore(),
     );
-    i.add<HomeScreenWidgetsCoordinator>(
-      () => HomeScreenWidgetsCoordinator(
+    i.add<Phase0HomeScreenWidgetsCoordinator>(
+      () => Phase0HomeScreenWidgetsCoordinator(
+        gestureCross: Modular.get<GestureCrossStore>(),
+        wifiDisconnectOverlay: Modular.get<WifiDisconnectOverlayStore>(),
+        beachWaves: Modular.get<BeachWavesStore>(),
+      ),
+    );
+    i.add<Phase1HomeScreenWidgetsCoordinator>(
+      () => Phase1HomeScreenWidgetsCoordinator(
+        nokhteBlur: Modular.get<NokhteBlurStore>(),
+        primarySmartText: Modular.get<SmartTextStore>(),
+        wifiDisconnectOverlay: Modular.get<WifiDisconnectOverlayStore>(),
+        gestureCross: Modular.get<GestureCrossStore>(),
+        beachWaves: Modular.get<BeachWavesStore>(),
+      ),
+    );
+    i.add<Phase2HomeScreenWidgetsCoordinator>(
+      () => Phase2HomeScreenWidgetsCoordinator(
+        nokhteBlur: Modular.get<NokhteBlurStore>(),
+        primarySmartText: Modular.get<SmartTextStore>(),
+        wifiDisconnectOverlay: Modular.get<WifiDisconnectOverlayStore>(),
+        gestureCross: Modular.get<GestureCrossStore>(),
+        beachWaves: Modular.get<BeachWavesStore>(),
+      ),
+    );
+    i.add<Phase3HomeScreenWidgetsCoordinator>(
+      () => Phase3HomeScreenWidgetsCoordinator(
         nokhteBlur: Modular.get<NokhteBlurStore>(),
         primarySmartText: Modular.get<SmartTextStore>(),
         wifiDisconnectOverlay: Modular.get<WifiDisconnectOverlayStore>(),

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/coordinators.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/coordinators.dart
@@ -1,2 +1,6 @@
 export './home_screen_coordinator.dart';
 export './home_screen_widgets_coordinator.dart';
+export './phase0/phase0.dart';
+export "./phase1/phase1.dart";
+export "./phase2/phase2.dart";
+export "./phase3/phase3.dart";

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/home_screen_widgets_coordinator.dart
@@ -169,9 +169,10 @@ abstract class _HomeScreenWidgetsCoordinatorBase extends BaseWidgetsCoordinator
         repeatTheFlow();
         toggleWantsToRepeatInvitationFlow();
         gestureCross.stopBlinking();
-        if (gracePeriodHasExpired) {
+        if (gracePeriodHasExpired && !hasCompletedASession) {
           primarySmartText.startRotatingText(isResuming: true);
-        } else if (!gracePeriodHasExpired) {
+        } else if (!gracePeriodHasExpired ||
+            (gracePeriodHasExpired && hasCompletedASession)) {
           primarySmartText.setCurrentIndex(1);
           primarySmartText.startRotatingText();
         }

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0.dart
@@ -1,0 +1,2 @@
+export "phase0_home_screen_coordinator.dart";
+export 'phase0_home_screen_widgets_coordinator.dart';

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0_home_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0_home_screen_coordinator.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'dart:async';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/modules/delete_unconsecrated_collaborations/mobx/mobx.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/collaboration/presentation/presentation.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_router_coordinator.dart';
+
+import 'phase0_home_screen_widgets_coordinator.dart';
+part 'phase0_home_screen_coordinator.g.dart';
+
+class Phase0HomeScreenCoordinator = _Phase0HomeScreenCoordinatorBase
+    with _$Phase0HomeScreenCoordinator;
+
+abstract class _Phase0HomeScreenCoordinatorBase
+    extends BaseHomeScreenRouterCoordinator with Store {
+  final DeleteUnconsecratedCollaborationsCoordinator
+      deleteUnconsecratedCollaborations;
+  final Phase0HomeScreenWidgetsCoordinator widgets;
+  final CollaborationLogicCoordinator collaborationLogic;
+
+  @observable
+  bool isConnected = true;
+
+  @action
+  setIsConnected(bool newVal) => isConnected = newVal;
+
+  _Phase0HomeScreenCoordinatorBase({
+    required this.deleteUnconsecratedCollaborations,
+    required super.getUserInfo,
+    required this.collaborationLogic,
+    required this.widgets,
+  });
+
+  @action
+  constructor() async {
+    widgets.constructor();
+    initReactors();
+    await deleteUnconsecratedCollaborations(NoParams());
+    await decideAndRoute(setParams);
+  }
+
+  @action
+  setParams() {
+    params = ResumeOnShoreParams(
+      direction: widgets.waterDirection,
+      position: widgets.beachWaves.currentAnimationValues.first,
+    );
+  }
+
+  initReactors() {
+    widgets.wifiDisconnectOverlay.initReactors(
+      onQuickConnected: () async {
+        widgets.onConnected();
+        setIsConnected(true);
+      },
+      onLongReConnected: () async {
+        await decideAndRoute(setParams);
+        widgets.onConnected();
+        setIsConnected(true);
+      },
+      onDisconnected: () {
+        widgets.onDisconnected();
+        setIsConnected(false);
+      },
+    );
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0_home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase0/phase0_home_screen_widgets_coordinator.dart
@@ -1,0 +1,43 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/mobx/mobx.dart';
+import 'package:nokhte/app/core/widgets/widget_constants.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'phase0_home_screen_widgets_coordinator.g.dart';
+
+class Phase0HomeScreenWidgetsCoordinator = _Phase0HomeScreenWidgetsCoordinatorBase
+    with _$Phase0HomeScreenWidgetsCoordinator;
+
+abstract class _Phase0HomeScreenWidgetsCoordinatorBase
+    extends BaseWidgetsCoordinator with Store {
+  final BeachWavesStore beachWaves;
+  final WifiDisconnectOverlayStore wifiDisconnectOverlay;
+  final GestureCrossStore gestureCross;
+
+  _Phase0HomeScreenWidgetsCoordinatorBase({
+    required this.beachWaves,
+    required this.wifiDisconnectOverlay,
+    required this.gestureCross,
+  });
+
+  @observable
+  WaterDirection waterDirection = WaterDirection.down;
+
+  @action
+  constructor() {
+    beachWaves.setMovieMode(BeachWaveMovieModes.onShore);
+    beachWaves.currentStore.setControl(Control.mirror);
+    gestureCross.setHomeScreen();
+  }
+
+  @action
+  onDisconnected() {
+    beachWaves.currentStore.setControl(Control.playReverse);
+  }
+
+  @action
+  onConnected() {
+    beachWaves.currentStore.setControl(Control.mirror);
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1.dart
@@ -1,0 +1,2 @@
+export 'phase1_home_screen_coordinator.dart';
+export 'phase1_home_screen_widgets_coordinator.dart';

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1_home_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1_home_screen_coordinator.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api, overridden_fields, annotate_overrides
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_coordinator.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/mobx.dart';
+part 'phase1_home_screen_coordinator.g.dart';
+
+class Phase1HomeScreenCoordinator = _Phase1HomeScreenCoordinatorBase
+    with _$Phase1HomeScreenCoordinator;
+
+abstract class _Phase1HomeScreenCoordinatorBase
+    extends BaseHomeScreenCoordinator with Store {
+  final Phase1HomeScreenWidgetsCoordinator widgets;
+  _Phase1HomeScreenCoordinatorBase({
+    required super.collaborationLogic,
+    required super.swipe,
+    required this.widgets,
+    required super.deepLinks,
+  }) : super(widgets: widgets);
+
+  @action
+  constructor() {
+    widgets.constructor();
+    initReactors();
+  }
+
+  @override
+  initReactors() {
+    super.initReactors();
+    swipeReactor(widgets.onSwipeUp);
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1_home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase1/phase1_home_screen_widgets_coordinator.dart
@@ -1,0 +1,68 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/extensions/extensions.dart';
+import 'package:nokhte/app/core/widgets/widget_constants.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_widgets_coordinator.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'phase1_home_screen_widgets_coordinator.g.dart';
+
+class Phase1HomeScreenWidgetsCoordinator = _Phase1HomeScreenWidgetsCoordinatorBase
+    with _$Phase1HomeScreenWidgetsCoordinator;
+
+abstract class _Phase1HomeScreenWidgetsCoordinatorBase
+    extends BaseHomeScreenWidgetsCoordinator with Store {
+  _Phase1HomeScreenWidgetsCoordinatorBase({
+    required super.nokhteBlur,
+    required super.beachWaves,
+    required super.wifiDisconnectOverlay,
+    required super.gestureCross,
+    required super.primarySmartText,
+  });
+
+  @observable
+  ResumeOnShoreParams params = ResumeOnShoreParams.initial();
+
+  @action
+  constructor() {
+    if (Modular.args.data["resumeOnShoreParams"] != null) {
+      params = Modular.args.data["resumeOnShoreParams"];
+    }
+    beachWaves.setMovieMode(BeachWaveMovieModes.resumeOnShore);
+    beachWaves.currentStore.initMovie(Modular.args.data["resumeOnShoreParams"]);
+    gestureCross.setHomeScreen();
+    primarySmartText.setMessagesData(MessagesData.firstTimeHomeList);
+    primarySmartText.startRotatingText();
+    initReactors();
+  }
+
+  @action
+  @override
+  initReactors() {
+    gestureCrossTapReactor();
+    super.initReactors();
+  }
+
+  @action
+  onSwipeUp() {
+    if (primarySmartText.currentIndex.equals(1) && !hasSwipedUp) {
+      prepForNavigation();
+    }
+  }
+
+  gestureCrossTapReactor() => reaction(
+        (p0) => gestureCross.tapCount,
+        (p0) => onGestureCrossTap(),
+      );
+
+  @action
+  onGestureCrossTap() {
+    if (!hasInitiatedBlur && !isEnteringNokhteSession) {
+      nokhteBlur.init();
+      beachWaves.currentStore.setControl(Control.stop);
+      toggleHasInitiatedBlur();
+      primarySmartText.startRotatingText(isResuming: true);
+    }
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2.dart
@@ -1,0 +1,2 @@
+export "./phase2_home_screen_coordinator.dart";
+export "./phase2_home_screen_widgets_coordinator.dart";

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2_home_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2_home_screen_coordinator.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api, overridden_fields, annotate_overrides
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_coordinator.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/mobx.dart';
+part 'phase2_home_screen_coordinator.g.dart';
+
+class Phase2HomeScreenCoordinator = _Phase2HomeScreenCoordinatorBase
+    with _$Phase2HomeScreenCoordinator;
+
+abstract class _Phase2HomeScreenCoordinatorBase
+    extends BaseHomeScreenCoordinator with Store {
+  final Phase2HomeScreenWidgetsCoordinator widgets;
+  _Phase2HomeScreenCoordinatorBase({
+    required super.collaborationLogic,
+    required super.swipe,
+    required this.widgets,
+    required super.deepLinks,
+  }) : super(widgets: widgets);
+
+  @action
+  constructor() {
+    widgets.constructor();
+    initReactors();
+  }
+
+  @override
+  initReactors() {
+    super.initReactors();
+    swipeReactor(widgets.onSwipeUp);
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2_home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase2/phase2_home_screen_widgets_coordinator.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widget_constants.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_widgets_coordinator.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'phase2_home_screen_widgets_coordinator.g.dart';
+
+class Phase2HomeScreenWidgetsCoordinator = _Phase2HomeScreenWidgetsCoordinatorBase
+    with _$Phase2HomeScreenWidgetsCoordinator;
+
+abstract class _Phase2HomeScreenWidgetsCoordinatorBase
+    extends BaseHomeScreenWidgetsCoordinator with Store {
+  _Phase2HomeScreenWidgetsCoordinatorBase({
+    required super.nokhteBlur,
+    required super.beachWaves,
+    required super.wifiDisconnectOverlay,
+    required super.gestureCross,
+    required super.primarySmartText,
+  });
+
+  @observable
+  bool gracePeriodHasExpired = false;
+
+  @observable
+  bool crossHasBeenTapped = false;
+
+  @action
+  toggleGracePeriodHasExpired() =>
+      gracePeriodHasExpired = !gracePeriodHasExpired;
+
+  @observable
+  ResumeOnShoreParams params = ResumeOnShoreParams.initial();
+
+  @action
+  constructor() {
+    if (Modular.args.data["resumeOnShoreParams"] != null) {
+      params = Modular.args.data["resumeOnShoreParams"];
+    }
+    beachWaves.setMovieMode(BeachWaveMovieModes.resumeOnShore);
+    beachWaves.currentStore.initMovie(Modular.args.data["resumeOnShoreParams"]);
+    primarySmartText.setMessagesData(MessagesData.firstTimeHomeList);
+    gestureCross.setHomeScreen();
+    Future.delayed(Seconds.get(3), () {
+      if (!hasSwipedUp) {
+        gestureCross.startBlinking();
+        primarySmartText.startRotatingText();
+        toggleGracePeriodHasExpired();
+      }
+    });
+    initReactors();
+  }
+
+  @action
+  @override
+  initReactors() {
+    gestureCrossTapReactor();
+    super.initReactors();
+  }
+
+  @action
+  onSwipeUp() {
+    if (!hasSwipedUp) {
+      toggleHasSwipedUp();
+      prepForNavigation(excludeUnBlur: !hasSwipedUp);
+    }
+  }
+
+  gestureCrossTapReactor() => reaction(
+        (p0) => gestureCross.tapCount,
+        (p0) => onGestureCrossTap(),
+      );
+
+  @action
+  onGestureCrossTap() {
+    if (!hasInitiatedBlur && !isEnteringNokhteSession) {
+      nokhteBlur.init();
+      beachWaves.currentStore.setControl(Control.stop);
+      toggleHasInitiatedBlur();
+      gestureCross.stopBlinking();
+      if (gracePeriodHasExpired) {
+        primarySmartText.startRotatingText(isResuming: true);
+      } else {
+        primarySmartText.setCurrentIndex(1);
+        primarySmartText.startRotatingText();
+      }
+    }
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3.dart
@@ -1,0 +1,2 @@
+export "phase3_home_screen_coordinator.dart";
+export "phase3_home_screen_widgets_coordinator.dart";

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3_home_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3_home_screen_coordinator.dart
@@ -1,0 +1,32 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api, annotate_overrides, overridden_fields
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_coordinator.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/mobx.dart';
+part 'phase3_home_screen_coordinator.g.dart';
+
+class Phase3HomeScreenCoordinator = _Phase3HomeScreenCoordinatorBase
+    with _$Phase3HomeScreenCoordinator;
+
+abstract class _Phase3HomeScreenCoordinatorBase
+    extends BaseHomeScreenCoordinator with Store {
+  final Phase3HomeScreenWidgetsCoordinator widgets;
+
+  _Phase3HomeScreenCoordinatorBase({
+    required super.collaborationLogic,
+    required super.swipe,
+    required super.deepLinks,
+    required this.widgets,
+  }) : super(widgets: widgets);
+
+  @action
+  constructor() {
+    widgets.constructor();
+    initReactors();
+  }
+
+  @override
+  initReactors() {
+    super.initReactors();
+    swipeReactor(widgets.onSwipeUp);
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3_home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/phase3/phase3_home_screen_widgets_coordinator.dart
@@ -1,0 +1,70 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/widgets/widget_constants.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_widgets_coordinator.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'phase3_home_screen_widgets_coordinator.g.dart';
+
+class Phase3HomeScreenWidgetsCoordinator = _Phase3HomeScreenWidgetsCoordinatorBase
+    with _$Phase3HomeScreenWidgetsCoordinator;
+
+abstract class _Phase3HomeScreenWidgetsCoordinatorBase
+    extends BaseHomeScreenWidgetsCoordinator with Store {
+  _Phase3HomeScreenWidgetsCoordinatorBase({
+    required super.nokhteBlur,
+    required super.beachWaves,
+    required super.wifiDisconnectOverlay,
+    required super.gestureCross,
+    required super.primarySmartText,
+  });
+
+  @observable
+  ResumeOnShoreParams params = ResumeOnShoreParams.initial();
+
+  @action
+  constructor() {
+    if (Modular.args.data["resumeOnShoreParams"] != null) {
+      params = Modular.args.data["resumeOnShoreParams"];
+    }
+    beachWaves.setMovieMode(BeachWaveMovieModes.resumeOnShore);
+    beachWaves.currentStore.initMovie(Modular.args.data["resumeOnShoreParams"]);
+    gestureCross.setHomeScreen();
+    primarySmartText.setMessagesData(MessagesData.firstTimeHomeList);
+    initReactors();
+  }
+
+  @action
+  @override
+  initReactors() {
+    super.initReactors();
+    gestureCrossTapReactor();
+  }
+
+  @action
+  onSwipeUp() {
+    if (!hasSwipedUp) {
+      toggleHasSwipedUp();
+      prepForNavigation(excludeUnBlur: !hasSwipedUp);
+    }
+  }
+
+  gestureCrossTapReactor() => reaction(
+        (p0) => gestureCross.tapCount,
+        (p0) => onGestureCrossTap(),
+      );
+
+  @action
+  onGestureCrossTap() {
+    if (!hasInitiatedBlur && !isEnteringNokhteSession) {
+      nokhteBlur.init();
+      beachWaves.currentStore.setControl(Control.stop);
+      toggleHasInitiatedBlur();
+      gestureCross.stopBlinking();
+
+      primarySmartText.setCurrentIndex(1);
+      primarySmartText.startRotatingText();
+    }
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_coordinator.dart
@@ -1,0 +1,124 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'dart:async';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/mobx/mobx.dart';
+import 'package:nokhte/app/core/modules/deep_links/mobx/mobx.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/collaboration/domain/logic/logic.dart';
+import 'package:nokhte/app/modules/collaboration/presentation/presentation.dart';
+import 'package:nokhte_backend/edge_functions/edge_functions.dart';
+
+import 'base_home_screen_widgets_coordinator.dart';
+part 'base_home_screen_coordinator.g.dart';
+
+class BaseHomeScreenCoordinator = _BaseHomeScreenCoordinatorBase
+    with _$BaseHomeScreenCoordinator;
+
+abstract class _BaseHomeScreenCoordinatorBase extends BaseCoordinator
+    with Store {
+  final BaseHomeScreenWidgetsCoordinator widgets;
+  final SwipeDetector swipe;
+  final CollaborationLogicCoordinator collaborationLogic;
+  final DeepLinksCoordinator deepLinks;
+
+  _BaseHomeScreenCoordinatorBase({
+    required this.collaborationLogic,
+    required this.swipe,
+    required this.widgets,
+    required this.deepLinks,
+  });
+
+  initReactors() {
+    deepLinks.listen();
+    widgets.wifiDisconnectOverlay.initReactors(
+      onQuickConnected: () => setDisableAllTouchFeedback(false),
+      onLongReConnected: () {
+        widgets.onLongReconnected();
+        setDisableAllTouchFeedback(false);
+      },
+      onDisconnected: () {
+        setDisableAllTouchFeedback(true);
+        widgets.onDisconnected();
+      },
+    );
+    widgets.beachWavesMovieStatusReactor(
+      onShoreToOceanDiveComplete,
+      onShoreToVibrantBlueComplete,
+    );
+    collaboratorPoolEntryReactor();
+    openedDeepLinksReactor();
+  }
+
+  @action
+  onResumed() {
+    ifTouchIsNotDisabled(() {
+      widgets.onResumed();
+    });
+  }
+
+  @action
+  onInactive() {
+    ifTouchIsNotDisabled(() {
+      widgets.onInactive();
+    });
+  }
+
+  @action
+  onShoreToOceanDiveComplete() => Modular.to.navigate(
+        '/collaboration/',
+        arguments: deepLinks.listenForOpenedDeepLinkStore.additionalMetadata,
+      );
+
+  @action
+  onShoreToVibrantBlueComplete() => Modular.to.navigate(
+        '/collaboration/pool',
+        arguments: deepLinks.listenForOpenedDeepLinkStore.additionalMetadata,
+      );
+
+  swipeReactor(Function onSwipeUp) =>
+      reaction((p0) => swipe.directionsType, (p0) {
+        switch (p0) {
+          case GestureDirections.up:
+            if (!widgets.isEnteringNokhteSession) {
+              ifTouchIsNotDisabled(() {
+                onSwipeUp();
+              });
+            }
+          default:
+            break;
+        }
+      });
+
+  collaboratorPoolEntryReactor() =>
+      reaction((p0) => collaborationLogic.hasEntered, (p0) async {
+        if (p0) {
+          Timer.periodic(
+            const Duration(seconds: 1),
+            (timer) async {
+              if (widgets.beachWaves.movieStatus == MovieStatus.finished &&
+                  widgets.isEnteringNokhteSession) {
+                Modular.to.navigate('/collaboration/pool');
+                timer.cancel();
+              }
+            },
+          );
+        }
+      });
+
+  openedDeepLinksReactor() =>
+      reaction((p0) => deepLinks.listenForOpenedDeepLinkStore.path, (p0) async {
+        if (deepLinks.listenForOpenedDeepLinkStore
+                .additionalMetadata["isTheUsersInvitation"] !=
+            null) {
+          final additionalMetadata =
+              deepLinks.listenForOpenedDeepLinkStore.additionalMetadata;
+          await collaborationLogic.enter(EnterCollaboratorPoolParams(
+            collaboratorUID: additionalMetadata["deepLinkUID"],
+            invitationType: InvitationType.nokhteSession,
+          ));
+          widgets.onDeepLinkOpened();
+        }
+      });
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_router_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_router_coordinator.dart
@@ -1,0 +1,54 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/interfaces/logic.dart';
+import 'package:nokhte/app/core/mobx/mobx.dart';
+import 'package:nokhte/app/core/modules/user_information/mobx/mobx.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+part 'base_home_screen_router_coordinator.g.dart';
+
+class BaseHomeScreenRouterCoordinator = _BaseHomeScreenRouterCoordinatorBase
+    with _$BaseHomeScreenRouterCoordinator;
+
+abstract class _BaseHomeScreenRouterCoordinatorBase extends BaseCoordinator
+    with Store {
+  final GetUserInfoStore getUserInfo;
+
+  _BaseHomeScreenRouterCoordinatorBase({
+    required this.getUserInfo,
+  });
+
+  @observable
+  ResumeOnShoreParams params = ResumeOnShoreParams.initial();
+
+  @action
+  decideAndRoute(Function setParams) async {
+    await getUserInfo(NoParams());
+    setParams();
+    final args = {"resumeOnShoreParams": params};
+    if (!getUserInfo.hasGoneThroughInvitationFlow) {
+      Modular.to.navigate("/home/phase1", arguments: args);
+    } else if (getUserInfo.hasGoneThroughInvitationFlow &&
+        !getUserInfo.hasDoneASession) {
+      Modular.to.navigate("/home/phase2", arguments: args);
+    } else if (getUserInfo.hasDoneASession) {
+      Modular.to.navigate("/home/phase3", arguments: args);
+    }
+  }
+
+  @action
+  onAnimationComplete() {
+    final args = {"resumeOnShoreParams": params};
+    if (!getUserInfo.hasGoneThroughInvitationFlow) {
+      Modular.to.navigate("/home/phase1", arguments: args);
+    } else if (getUserInfo.hasGoneThroughInvitationFlow &&
+        !getUserInfo.hasDoneASession) {
+      Modular.to.navigate("/home/phase2", arguments: args);
+    } else if (getUserInfo.hasDoneASession) {
+      Modular.to.navigate("/home/phase3", arguments: args);
+    }
+  }
+
+  @override
+  List<Object> get props => [];
+}

--- a/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_widgets_coordinator.dart
+++ b/packages/client/lib/app/modules/home/presentation/mobx/coordinators/shared/base_home_screen_widgets_coordinator.dart
@@ -1,0 +1,176 @@
+// ignore_for_file: must_be_immutable, library_private_types_in_public_api
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:mobx/mobx.dart';
+import 'package:nokhte/app/core/mobx/mobx.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widget_constants.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:simple_animations/simple_animations.dart';
+part 'base_home_screen_widgets_coordinator.g.dart';
+
+class BaseHomeScreenWidgetsCoordinator = _BaseHomeScreenWidgetsCoordinatorBase
+    with _$BaseHomeScreenWidgetsCoordinator;
+
+abstract class _BaseHomeScreenWidgetsCoordinatorBase
+    extends BaseWidgetsCoordinator with Store {
+  final NokhteBlurStore nokhteBlur;
+  final BeachWavesStore beachWaves;
+  final WifiDisconnectOverlayStore wifiDisconnectOverlay;
+  final GestureCrossStore gestureCross;
+  final SmartTextStore primarySmartText;
+
+  _BaseHomeScreenWidgetsCoordinatorBase({
+    required this.nokhteBlur,
+    required this.beachWaves,
+    required this.wifiDisconnectOverlay,
+    required this.gestureCross,
+    required this.primarySmartText,
+  });
+
+  @observable
+  bool isEnteringNokhteSession = false;
+
+  @observable
+  bool hasSwipedUp = false;
+
+  @action
+  toggleHasSwipedUp() => hasSwipedUp = !hasSwipedUp;
+
+  @action
+  onConnected() {
+    onResumed();
+  }
+
+  @action
+  onDisconnected() {
+    onInactive();
+    if (beachWaves.movieMode == BeachWaveMovieModes.onShoreToVibrantBlue) {
+      isEnteringNokhteSession = false;
+      beachWaves.currentStore.setControl(Control.playReverse);
+    }
+  }
+
+  @action
+  onResumed() {
+    if (!hasInitiatedBlur) {
+      primarySmartText.startRotatingText();
+      if (hasInitiatedBlur) {
+        nokhteBlur.reverse();
+        toggleHasInitiatedBlur();
+      }
+    }
+  }
+
+  @action
+  onInactive() {
+    if (!hasInitiatedBlur) {
+      primarySmartText.reset();
+      if (!hasSwipedUp && beachWaves.movieMode == BeachWaveMovieModes.onShore) {
+        beachWaves.currentStore.setControl(Control.mirror);
+      }
+    }
+  }
+
+  @action
+  prepForNavigation({bool excludeUnBlur = false}) {
+    toggleHasSwipedUp();
+    if (!excludeUnBlur) {
+      nokhteBlur.reverse();
+    }
+    gestureCross.stopBlinking();
+    if (primarySmartText.currentIndex == 0) {
+      primarySmartText.toggleWidgetVisibility();
+    } else {
+      primarySmartText.startRotatingText(isResuming: true);
+    }
+    beachWaves.setMovieMode(BeachWaveMovieModes.onShoreToOceanDive);
+    beachWaves.currentStore.initMovie(beachWaves.currentAnimationValues.first);
+    gestureCross.initMoveAndRegenerate(CircleOffsets.top);
+  }
+
+  @observable
+  bool hasInitiatedBlur = false;
+
+  @observable
+  bool isDoubleTriggeringWindDown = false;
+
+  @action
+  toggleIsDoubleTriggeringWindDown() =>
+      isDoubleTriggeringWindDown = !isDoubleTriggeringWindDown;
+
+  @action
+  toggleHasInitiatedBlur() => hasInitiatedBlur = !hasInitiatedBlur;
+
+  initReactors() {
+    nokhteBlurReactor();
+    centerCrossNokhteReactor();
+  }
+
+  centerCrossNokhteReactor() =>
+      reaction((p0) => gestureCross.centerCrossNokhte.movieStatus, (p0) {
+        if (p0 == MovieStatus.finished) {
+          gestureCross.gradientNokhte.toggleWidgetVisibility();
+          gestureCross.strokeCrossNokhte.toggleWidgetVisibility();
+        }
+      });
+
+  @action
+  onLongReconnected() {
+    if (wifiDisconnectOverlay.movieMode ==
+        WifiDisconnectMovieModes.removeTheCircle) {
+      if (isDisconnected) setIsDisconnected(false);
+      if (primarySmartText.isPaused) {
+        primarySmartText.resume();
+      }
+      if (hasSwipedUp) {
+        beachWaves.currentStore.setControl(Control.playFromStart);
+        beachWaves.setMovieStatus(MovieStatus.inProgress);
+      }
+      if (beachWaves.movieMode == BeachWaveMovieModes.onShoreToVibrantBlue) {
+        isEnteringNokhteSession = true;
+        beachWaves.currentStore.setControl(Control.playFromStart);
+      }
+    }
+  }
+
+  nokhteBlurReactor() => reaction((p0) => nokhteBlur.movieStatus, (p0) {
+        if (p0 == MovieStatus.finished &&
+            nokhteBlur.pastControl == Control.playReverseFromEnd) {}
+      });
+
+  beachWavesMovieStatusReactor(
+    Function onShoreToOceanDiveComplete,
+    Function onShoreToVibrantBlueComplete,
+  ) =>
+      reaction((p0) => beachWaves.movieStatus, (p0) {
+        if (p0 == MovieStatus.finished) {
+          if (beachWaves.movieMode == BeachWaveMovieModes.onShoreToOceanDive) {
+            onShoreToOceanDiveComplete();
+          } else if (beachWaves.movieMode ==
+              BeachWaveMovieModes.onShoreToVibrantBlue) {
+            if (isEnteringNokhteSession) {
+              onShoreToVibrantBlueComplete();
+            } else {
+              beachWaves.setMovieStatus(MovieStatus.inProgress);
+            }
+          } else if (p0 == MovieStatus.finished &&
+              beachWaves.movieMode == BeachWaveMovieModes.resumeOnShore) {
+            beachWaves.setMovieMode(BeachWaveMovieModes.onShore);
+          }
+        } else if (beachWaves.movieStatus == MovieStatus.finished &&
+            isEnteringNokhteSession) {
+          Modular.to.navigate('/collaboration/pool');
+        }
+      });
+
+  @action
+  onDeepLinkOpened() {
+    isEnteringNokhteSession = true;
+    primarySmartText.toggleWidgetVisibility();
+    beachWaves.setMovieMode(BeachWaveMovieModes.onShoreToVibrantBlue);
+    beachWaves.currentStore.initMovie(
+      beachWaves.currentAnimationValues.first,
+    );
+    gestureCross.toggleAll();
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/presentation.dart
+++ b/packages/client/lib/app/modules/home/presentation/presentation.dart
@@ -1,2 +1,2 @@
 export 'mobx/mobx.dart';
-export 'screens/home_screen.dart';
+export 'screens/screens.dart';

--- a/packages/client/lib/app/modules/home/presentation/screens/phase0_home_screen.dart
+++ b/packages/client/lib/app/modules/home/presentation/screens/phase0_home_screen.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: must_be_immutable
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:nokhte/app/core/hooks/hooks.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/presentation.dart';
+
+class Phase0HomeScreen extends HookWidget {
+  final Phase0HomeScreenCoordinator coordinator;
+  const Phase0HomeScreen({
+    super.key,
+    required this.coordinator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = useSquareSize(relativeLength: .20);
+    useEffect(() {
+      coordinator.constructor();
+      return null;
+    }, []);
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: MultiHitStack(
+        children: [
+          Hero(
+            tag: "beach",
+            child: FullScreen(
+                child: BeachWaves(
+              store: coordinator.widgets.beachWaves,
+            )),
+          ),
+          GestureCross(
+            config: GestureCrossConfiguration(
+              top: Right(
+                NokhteGradientConfig(
+                  gradientType: NokhteGradientTypes.vibrantBlue,
+                ),
+              ),
+            ),
+            size: size,
+            store: coordinator.widgets.gestureCross,
+          ),
+          WifiDisconnectOverlay(
+            store: coordinator.widgets.wifiDisconnectOverlay,
+          ),
+        ],
+      ),
+      // ),
+    );
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/screens/phase1_home_screen.dart
+++ b/packages/client/lib/app/modules/home/presentation/screens/phase1_home_screen.dart
@@ -1,0 +1,70 @@
+// ignore_for_file: must_be_immutable
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:nokhte/app/core/hooks/hooks.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/presentation.dart';
+
+class Phase1HomeScreen extends HookWidget {
+  final Phase1HomeScreenCoordinator coordinator;
+  const Phase1HomeScreen({
+    super.key,
+    required this.coordinator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = useSquareSize(relativeLength: .20);
+    useEffect(() {
+      coordinator.constructor();
+      return null;
+    }, []);
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Swipe(
+        store: coordinator.swipe,
+        child: MultiHitStack(
+          children: [
+            Hero(
+              tag: 'beach',
+              child: FullScreen(
+                child: BeachWaves(
+                  store: coordinator.widgets.beachWaves,
+                ),
+              ),
+            ),
+            FullScreen(
+              child: NokhteBlur(
+                store: coordinator.widgets.nokhteBlur,
+              ),
+            ),
+            Center(
+              child: SmartText(
+                store: coordinator.widgets.primarySmartText,
+                bottomPadding: 180,
+                opacityDuration: Seconds.get(1),
+              ),
+            ),
+            GestureCross(
+              config: GestureCrossConfiguration(
+                top: Right(
+                  NokhteGradientConfig(
+                    gradientType: NokhteGradientTypes.vibrantBlue,
+                  ),
+                ),
+              ),
+              size: size,
+              store: coordinator.widgets.gestureCross,
+            ),
+            WifiDisconnectOverlay(
+              store: coordinator.widgets.wifiDisconnectOverlay,
+            ),
+          ],
+        ),
+      ),
+      // ),
+    );
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/screens/phase2_home_screen.dart
+++ b/packages/client/lib/app/modules/home/presentation/screens/phase2_home_screen.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: must_be_immutable
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:nokhte/app/core/hooks/hooks.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/presentation.dart';
+
+class Phase2HomeScreen extends HookWidget {
+  final Phase2HomeScreenCoordinator coordinator;
+  const Phase2HomeScreen({
+    super.key,
+    required this.coordinator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = useSquareSize(relativeLength: .20);
+    useEffect(() {
+      coordinator.constructor();
+      return null;
+    }, []);
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Swipe(
+        store: coordinator.swipe,
+        child: MultiHitStack(
+          children: [
+            Hero(
+              tag: 'beach',
+              child: FullScreen(
+                child: BeachWaves(
+                  store: coordinator.widgets.beachWaves,
+                ),
+              ),
+            ),
+            FullScreen(
+              child: NokhteBlur(
+                store: coordinator.widgets.nokhteBlur,
+              ),
+            ),
+            Center(
+              child: SmartText(
+                store: coordinator.widgets.primarySmartText,
+                bottomPadding: 180,
+                opacityDuration: Seconds.get(1),
+              ),
+            ),
+            GestureCross(
+              config: GestureCrossConfiguration(
+                top: Right(
+                  NokhteGradientConfig(
+                    gradientType: NokhteGradientTypes.vibrantBlue,
+                  ),
+                ),
+              ),
+              size: size,
+              store: coordinator.widgets.gestureCross,
+            ),
+            WifiDisconnectOverlay(
+              store: coordinator.widgets.wifiDisconnectOverlay,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/screens/phase3_home_screen.dart
+++ b/packages/client/lib/app/modules/home/presentation/screens/phase3_home_screen.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: must_be_immutable
+import 'package:dartz/dartz.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:nokhte/app/core/hooks/hooks.dart';
+import 'package:nokhte/app/core/types/types.dart';
+import 'package:nokhte/app/core/widgets/widgets.dart';
+import 'package:nokhte/app/modules/home/presentation/presentation.dart';
+
+class Phase3HomeScreen extends HookWidget {
+  final Phase3HomeScreenCoordinator coordinator;
+  const Phase3HomeScreen({
+    super.key,
+    required this.coordinator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = useSquareSize(relativeLength: .20);
+    useEffect(() {
+      coordinator.constructor();
+      return null;
+    }, []);
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Swipe(
+        store: coordinator.swipe,
+        child: MultiHitStack(
+          children: [
+            Hero(
+              tag: 'beach',
+              child: FullScreen(
+                child: BeachWaves(
+                  store: coordinator.widgets.beachWaves,
+                ),
+              ),
+            ),
+            FullScreen(
+              child: NokhteBlur(
+                store: coordinator.widgets.nokhteBlur,
+              ),
+            ),
+            Center(
+              child: SmartText(
+                store: coordinator.widgets.primarySmartText,
+                bottomPadding: 180,
+                opacityDuration: Seconds.get(1),
+              ),
+            ),
+            GestureCross(
+              config: GestureCrossConfiguration(
+                top: Right(
+                  NokhteGradientConfig(
+                    gradientType: NokhteGradientTypes.vibrantBlue,
+                  ),
+                ),
+              ),
+              size: size,
+              store: coordinator.widgets.gestureCross,
+            ),
+            WifiDisconnectOverlay(
+              store: coordinator.widgets.wifiDisconnectOverlay,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/client/lib/app/modules/home/presentation/screens/screens.dart
+++ b/packages/client/lib/app/modules/home/presentation/screens/screens.dart
@@ -1,0 +1,4 @@
+export "./phase0_home_screen.dart";
+export "./phase1_home_screen.dart";
+export "./phase2_home_screen.dart";
+export "./phase3_home_screen.dart";

--- a/packages/client/test/app/modules/authentication/presentation/mobx/coordinators/login_screen_coordinator_test.dart
+++ b/packages/client/test/app/modules/authentication/presentation/mobx/coordinators/login_screen_coordinator_test.dart
@@ -3,6 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:nokhte/app/core/interfaces/auth_providers.dart';
 import 'package:nokhte/app/core/widgets/widgets.dart';
 import 'package:nokhte/app/modules/authentication/presentation/presentation.dart';
+import '../../../../home/fixtures/home_stack_mock_gen.mocks.dart';
 import '../../../../shared/shared_mocks.mocks.dart';
 import '../../../fixtures/authentication_stack_mock_gen.mocks.dart';
 
@@ -46,6 +47,7 @@ void main() {
     mockSwipeDetector = SwipeDetector();
     mockTapDetector = TapDetector();
     testStore = LoginScreenCoordinator(
+      getUserInfo: MockGetUserInfoStore(),
       addName: mockAddNameToDatabase,
       widgets: mockWidgetsStore,
       signInWithAuthProvider: mockAuthProviderStore,


### PR DESCRIPTION
This includes 4 different phases
1. phase 0 is the decider screen (try disconnecting from internet & entering the app, hard to do in development)
2. phase 1 => haven't sent an invitation nor done a session
3. phase 2 => has sent an invitation
4. phase 3 => has done a session

you may need to go into supabase to test how each of these act in the wild, but test initial disconnection & reconnection on all screens, they should act as they normally would