### PR TITLE
v1 home screen patches & ios version bump

### DIFF
--- a/packages/client/ios/fastlane/report.xml
+++ b/packages/client/ios/fastlane/report.xml
@@ -5,17 +5,17 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: update_fastlane" time="6.656546">
+      <testcase classname="fastlane.lanes" name="0: update_fastlane" time="8.631066">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.000134">
+      <testcase classname="fastlane.lanes" name="1: default_platform" time="0.000466">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: flutter_version_manager" time="0.261901">
+      <testcase classname="fastlane.lanes" name="2: flutter_version_manager" time="0.310063">
         
       </testcase>
     

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -2,7 +2,7 @@ name: nokhte
 description: A new Flutter project.
 publish_to: "none"
 
-version: 0.9.0+109129184
+version: 0.10.0+109228750
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/packages/client/version.yml
+++ b/packages/client/version.yml
@@ -1,4 +1,4 @@
 ---
 major: 0
-minor: 9
+minor: 10
 patch: 0


### PR DESCRIPTION
This includes 4 different phases
1. phase 0 is the decider screen (try disconnecting from internet & entering the app, hard to do in development)
2. phase 1 => haven't sent an invitation nor done a session
3. phase 2 => has sent an invitation
4. phase 3 => has done a session

you may need to go into supabase to test how each of these act in the wild, but test initial disconnection & reconnection on all screens, they should act as they normally would