### PR TITLE
146 staging & production testflight / app store setup

### DIFF
--- a/.github/workflows/client-production-ios-deploy.yml
+++ b/.github/workflows/client-production-ios-deploy.yml
@@ -26,14 +26,19 @@ jobs:
           echo "PROD_SUPABASE_URL='$PROD_SUPABASE_URL'" >> .env
           echo "PROD_SUPABASE_ANON_KEY='$PROD_SUPABASE_ANON_KEY'" >> .env
           echo "AGORA_APP_ID='$AGORA_APP_ID'" >> .env
+          echo "APP_ID='$APP_ID'" >> .env
         env:
           PROD_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
           PROD_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}
+          APP_ID: ${{ secrets.PROD_APP_ID }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"
           bundler-cache: true
+      - run: |
+          chmod +x ./scripts/setup_prod_build.zsh
+          ./scripts/setup_prod_build.zsh
       - run: flutter pub run build_runner build
       - run: cd ios && bundle install
       - run: cd ios && fastlane rebuild_ios_archive

--- a/.github/workflows/client-staging-ios-deploy.yml
+++ b/.github/workflows/client-staging-ios-deploy.yml
@@ -26,7 +26,9 @@ jobs:
           echo "PROD_SUPABASE_URL='$STAGING_SUPABASE_URL'" >> .env
           echo "PROD_SUPABASE_ANON_KEY='$STAGING_SUPABASE_ANON_KEY'" >> .env
           echo "AGORA_APP_ID='$AGORA_APP_ID'" >> .env
+          echo "APP_ID='$APP_ID'" >> .env
         env:
+          APP_ID: ${{ secrets.STAGING_APP_ID }}
           STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
           STAGING_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
           AGORA_APP_ID: ${{ secrets.AGORA_APP_ID }}

--- a/packages/backend/supabase/config.toml
+++ b/packages/backend/supabase/config.toml
@@ -40,10 +40,10 @@ file_size_limit = "50MiB"
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "com.nokhte.nokhte"
+site_url = "com.staging.nokhte"
 # site_url = "com.primala.primala"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["com.nokhte.nokhte://login-callback"]
+additional_redirect_urls = ["com.staging.nokhte://login-callback"]
 # additional_redirect_urls = ["com.primala.primala://login-callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).

--- a/packages/backend/supabase/config.toml
+++ b/packages/backend/supabase/config.toml
@@ -40,10 +40,9 @@ file_size_limit = "50MiB"
 [auth]
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "com.staging.nokhte"
-# site_url = "com.primala.primala"
+site_url = "com.nokhte.staging"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["com.staging.nokhte://login-callback"]
+additional_redirect_urls = ["com.nokhte.staging://login-callback"]
 # additional_redirect_urls = ["com.primala.primala://login-callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).

--- a/packages/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/client/ios/Runner.xcodeproj/project.pbxproj
@@ -549,7 +549,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 92SD3256WG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Nokhte;
+				INFOPLIST_KEY_CFBundleDisplayName = "Nokhte Staging";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -691,7 +691,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 92SD3256WG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Nokhte;
+				INFOPLIST_KEY_CFBundleDisplayName = "Nokhte Staging";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -725,7 +725,7 @@
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 92SD3256WG;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Nokhte;
+				INFOPLIST_KEY_CFBundleDisplayName = "Nokhte Staging";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/client/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/client/ios/Runner.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 87170510;
 				DEVELOPMENT_TEAM = "";
@@ -555,10 +555,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte;
+				PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.nokhte.nokhte";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.staging.nokhte";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -697,10 +697,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte;
+				PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.nokhte.nokhte";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.staging.nokhte";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -731,10 +731,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte;
+				PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.primala.primala";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.nokhte.nokhte";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.staging.nokhte";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/packages/client/ios/Runner/Info.plist
+++ b/packages/client/ios/Runner/Info.plist
@@ -28,10 +28,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.staging.nokhte</string>
+			<string>com.nokhte.staging</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.staging.nokhte</string>
+				<string>com.nokhte.staging</string>
 			</array>
 		</dict>
 	</array>

--- a/packages/client/ios/Runner/Info.plist
+++ b/packages/client/ios/Runner/Info.plist
@@ -28,10 +28,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.nokhte.nokhte</string>
+			<string>com.staging.nokhte</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.nokhte.nokhte</string>
+				<string>com.staging.nokhte</string>
 			</array>
 		</dict>
 	</array>
@@ -79,16 +79,16 @@
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>
-		<string>key_live_oFdaQmf0vYYD43VtksjHYlfmyzjlnKnL</string>
+		<string>key_live_hqdu5OWr8Tsdo7keyaCk1egjDykdkeRi</string>
 		<key>test</key>
-		<string>key_test_ayadRkn9EZ9xY7IFlqmQHnipzxiihPjD</string>
+		<string>key_test_kDgs4IXrYGvog6bgvesgWlooABmmjkLq</string>
 	</dict>
 	<key>branch_universal_link_domains</key>
 	<array>
-		<string>app.nokhte.com</string>
-		<string>2cf02-alternate.app.link</string>
-		<string>2cf02.test-app.link</string>
-		<string>2cf02-alternate.test-app.link</string>
+		<string>59q6i.app.link</string>
+		<string>59q6i-alternate.app.link</string>
+		<string>59q6i.test-app.link</string>
+		<string>59q6i-alternate.test-app.link</string>
 	</array>
 	<key>com.posthog.posthog.API_KEY</key>
 	<string>phc_qeWzqB1Jrx9cxa5mwr7HPsaeyHXzQcu59zBZdfY0riT</string>

--- a/packages/client/ios/fastlane/Appfile
+++ b/packages/client/ios/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier("com.nokhte.nokhte") 
+app_identifier("com.staging.nokhte") 
 apple_id("vesali.sonny@gmail.com") 
 
 itc_team_id("125570349")

--- a/packages/client/ios/fastlane/Matchfile
+++ b/packages/client/ios/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("https://github.com/nokhte/match_certificates")
+git_url("https://github.com/nokhte/staging_match_certificates")
 
 storage_mode("git")
 

--- a/packages/client/lib/app/modules/authentication/data/sources/auth_remote_source.dart
+++ b/packages/client/lib/app/modules/authentication/data/sources/auth_remote_source.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:nokhte/app/core/modules/user_information/data/data.dart';
 import 'package:nokhte/app/modules/authentication/data/models/models.dart';
 import 'package:nokhte/app/core/interfaces/auth_providers.dart';
@@ -27,10 +28,12 @@ class AuthenticationRemoteSourceImpl implements AuthenticationRemoteSource {
 
   @override
   signInWithGoogle() async {
+    await dotenv.load();
+    final bundleID = dotenv.env["APP_ID"];
     final res = await supabase.auth.signInWithOAuth(
       Provider.google,
       scopes: 'email profile openid',
-      redirectTo: kIsWeb ? null : 'com.nokhte.nokhte://login-callback',
+      redirectTo: kIsWeb ? null : '$bundleID://login-callback',
     );
     return AuthProviderModel(
         authProvider: AuthProvider.google, authProviderStatus: res);

--- a/packages/client/lib/main.dart
+++ b/packages/client/lib/main.dart
@@ -9,11 +9,17 @@ import 'package:flutter/foundation.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load();
+
+  final shouldUseTestKey =
+      dotenv.env["APP_ID"]!.contains('staging') || kDebugMode;
+
+  print("shouldUseTestKey: $shouldUseTestKey");
+
   await FlutterBranchSdk.init(
     disableTracking: true,
-    useTestKey: kDebugMode ? true : false,
+    useTestKey: shouldUseTestKey,
   );
-  await dotenv.load();
 
   late String supabaseUrl;
   late String supabaseAnonKey;

--- a/packages/client/pubspec.yaml
+++ b/packages/client/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter_mobx: ^2.2.0
   flutter_modular: ^6.3.2
   flutter_platform_widgets: ^3.3.5
-  google_fonts: ^6.1.0
+  google_fonts: ^5.1.0
   google_sign_in: ^6.1.4
   haptic_feedback: ^0.4.2
   http: ^1.1.0

--- a/packages/client/scripts/setup_prod_build.zsh
+++ b/packages/client/scripts/setup_prod_build.zsh
@@ -2,14 +2,9 @@
 cd ios/Runner
 # CFBundleURLName & Scheme
 sed -i '' -e 's/com.staging.nokhte/com.nokhte.nokhte/' info.plist  
-# branch keys
-sed -i '' -e 's/key_live_hqdu5OWr8Tsdo7keyaCk1egjDykdkeRi/key_live_oFdaQmf0vYYD43VtksjHYlfmyzjlnKnL/' info.plist  
-sed -i '' -e 's/key_test_kDgs4IXrYGvog6bgvesgWlooABmmjkLq/key_test_ayadRkn9EZ9xY7IFlqmQHnipzxiihPjD/' info.plist  
-# branch domains
-sed -i '' -e 's/59q6i.app.link/app.nokhte.com/' info.plist
-sed -i '' -e 's/59q6i-alternate.app.link/2cf02-alternate.app.link/' info.plist
-sed -i '' -e 's/59q6i.test-app.link/2cf02.test-app.link/' info.plist
-sed -i '' -e 's/59q6i-alternate.test-app.link/2cf02-alternate.test-app.link/' info.plist
+
+sed -i '' -e 's/staging_match_certificates/match_certificates/' Matchfile 
+
 # bundle id
 cd ../Runner.xcodeproj
 sed -i '' -e 's/PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte/PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte/' project.pbxproj  

--- a/packages/client/scripts/setup_prod_build.zsh
+++ b/packages/client/scripts/setup_prod_build.zsh
@@ -9,3 +9,4 @@ sed -i '' -e 's/com.staging.nokhte/com.nokhte.nokhte/' Appfile
 # bundle id
 cd ../Runner.xcodeproj
 sed -i '' -e 's/PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte/PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte/' project.pbxproj  
+sed -i '' -e 's/INFOPLIST_KEY_CFBundleDisplayName = "Nokhte Staging";/INFOPLIST_KEY_CFBundleDisplayName = Nokhte;/' project.pbxproj  

--- a/packages/client/scripts/setup_prod_build.zsh
+++ b/packages/client/scripts/setup_prod_build.zsh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+cd ios/Runner
+# CFBundleURLName & Scheme
+sed -i '' -e 's/com.staging.nokhte/com.nokhte.nokhte/' info.plist  
+# branch keys
+sed -i '' -e 's/key_live_hqdu5OWr8Tsdo7keyaCk1egjDykdkeRi/key_live_oFdaQmf0vYYD43VtksjHYlfmyzjlnKnL/' info.plist  
+sed -i '' -e 's/key_test_kDgs4IXrYGvog6bgvesgWlooABmmjkLq/key_test_ayadRkn9EZ9xY7IFlqmQHnipzxiihPjD/' info.plist  
+# branch domains
+sed -i '' -e 's/59q6i.app.link/app.nokhte.com/' info.plist
+sed -i '' -e 's/59q6i-alternate.app.link/2cf02-alternate.app.link/' info.plist
+sed -i '' -e 's/59q6i.test-app.link/2cf02.test-app.link/' info.plist
+sed -i '' -e 's/59q6i-alternate.test-app.link/2cf02-alternate.test-app.link/' info.plist
+# bundle id
+cd ../Runner.xcodeproj
+sed -i '' -e 's/PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte/PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte/' project.pbxproj  

--- a/packages/client/scripts/setup_prod_build.zsh
+++ b/packages/client/scripts/setup_prod_build.zsh
@@ -1,10 +1,11 @@
 #!/bin/zsh
 cd ios/Runner
 # CFBundleURLName & Scheme
-sed -i '' -e 's/com.staging.nokhte/com.nokhte.nokhte/' info.plist  
-
+sed -i '' -e 's/com.nokhte.staging/com.nokhte.nokhte/' info.plist  
+# fastlane configs
+cd ../fastlane
 sed -i '' -e 's/staging_match_certificates/match_certificates/' Matchfile 
-
+sed -i '' -e 's/com.staging.nokhte/com.nokhte.nokhte/' Appfile
 # bundle id
 cd ../Runner.xcodeproj
 sed -i '' -e 's/PRODUCT_BUNDLE_IDENTIFIER = com.staging.nokhte/PRODUCT_BUNDLE_IDENTIFIER = com.nokhte.nokhte/' project.pbxproj  


### PR DESCRIPTION
This closes #146 if it works, so what's included is
1. a shell script called `setup_prod_build.zsh` that does the heavy lifting of changing bundle naming & other relevant fields, and the necessary alterations to the staging & production workflows